### PR TITLE
Fix rendering of correct operation names in traces

### DIFF
--- a/src/day8/re_frame/trace.cljs
+++ b/src/day8/re_frame/trace.cljs
@@ -159,7 +159,9 @@
                                      :re-frame.router/fsm-trigger "#fd701e"
                                      nil)}}
                [:td {:style row-style} (str op-type)]
-               [:td {:style row-style} operation]
+               [:td {:style row-style} (if (= PersistentVector (type (js->clj operation)))
+                                         (second operation)
+                                         operation)]
                [:td
                 {:style (merge row-style {
                                           ; :font-weight (if (< slower-than-bold-int duration)


### PR DESCRIPTION
- at the moment, re-frame operations are being misinterpreted as hiccup forms
- example: `[:idle :add-event]` renders to custom html element `idle` containing value `add-event`
- prevent this behavior by checking for operation type
- fixes  #37