### PR TITLE
polish filtering 

### DIFF
--- a/src/day8/re_frame/trace.cljs
+++ b/src/day8/re_frame/trace.cljs
@@ -148,19 +148,18 @@
 
 (defn add-filter [filter-items filter-input filter-type]
   ;; prevent duplicate filter strings
-  (if-not (some #(= filter-input (:query %)) @filter-items)
-    (do
-      ;; if existing, remove prior filter for :slower-than
-      (when (and (= :slower-than filter-type)
-                 (some #(= filter-type (:filter-type %)) @filter-items))
-        (swap! filter-items (fn [item]
-                              (remove #(= :slower-than (:filter-type %)) item))))
-      ;; add new filter
-      (swap! filter-items conj {:id (random-uuid)
-                                :query (if (= filter-type :contains)
-                                         (str/lower-case filter-input)
-                                         (js/parseFloat filter-input))
-                                :filter-type filter-type}))))
+  (when-not (some #(= filter-input (:query %)) @filter-items)
+    ;; if existing, remove prior filter for :slower-than
+    (when (and (= :slower-than filter-type)
+               (some #(= filter-type (:filter-type %)) @filter-items))
+      (swap! filter-items (fn [item]
+                            (remove #(= :slower-than (:filter-type %)) item))))
+    ;; add new filter
+    (swap! filter-items conj {:id          (random-uuid)
+                              :query       (if (= filter-type :contains)
+                                             (str/lower-case filter-input)
+                                             (js/parseFloat filter-input))
+                              :filter-type filter-type})))
 
 (defn render-traces [showing-traces filter-items filter-input trace-detail-expansions]
   (doall

--- a/src/day8/re_frame/trace.cljs
+++ b/src/day8/re_frame/trace.cljs
@@ -147,11 +147,12 @@
       (< (:query query) (:duration trace)))))
 
 (defn add-filter [filter-items filter-input filter-type]
-  (swap! filter-items conj {:id (random-uuid)
-                            :query (if (= filter-type :contains)
-                                     (str/lower-case filter-input)
-                                     (js/parseFloat filter-input))
-                            :filter-type filter-type}))
+  (if-not (some #(= filter-input (:query %)) @filter-items)
+    (swap! filter-items conj {:id (random-uuid)
+                              :query (if (= filter-type :contains)
+                                       (str/lower-case filter-input)
+                                       (js/parseFloat filter-input))
+                              :filter-type filter-type})))
 
 (defn render-traces [showing-traces filter-items filter-input trace-detail-expansions]
   (doall


### PR DESCRIPTION
- prevent adding duplicate or conflicting filters
- don't create a new filter if already existing
- when adding a new time filter, remove existing ones

fixes #30