### PR TITLE
Print trace details to console on click

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ If you are using leiningen, modify `project.clj` in the following ways. When puz
                       :preloads             [day8.re-frame.trace.preload]}}]}
   ```
 
+[cljs-devtools](https://github.com/binaryage/cljs-devtools) is not required to use re-frame-trace, but it is highly recommended.
+
 ## Usage
 
 - Start up your application.

--- a/resources/day8/re_frame/trace/main.css
+++ b/resources/day8/re_frame/trace/main.css
@@ -98,3 +98,6 @@
 #--re-frame-trace-- .filter-control {
   margin: 10px 0 0 10px;
 }
+#--re-frame-trace-- .trace-details {
+  cursor: pointer;
+}

--- a/resources/day8/re_frame/trace/main.less
+++ b/resources/day8/re_frame/trace/main.less
@@ -105,4 +105,8 @@
   .filter-control {
     margin: 10px 0 0 10px;
   }
+  .trace-details {
+    cursor: pointer;
+  }
 }
+

--- a/src/day8/re_frame/trace.cljs
+++ b/src/day8/re_frame/trace.cljs
@@ -200,7 +200,7 @@
               (when show-row?
                 [:tr {:key (str id "-details")}
                  [:td.trace-details {:col-span 3
-                                     :on-click #(.log js/console (clj->js tags))}
+                                     :on-click #(.log js/console tags)}
                    (let [tag-str (with-out-str (pprint/pprint tags))
                          string-size-limit 400]
                         (if (< string-size-limit (count tag-str))

--- a/src/day8/re_frame/trace.cljs
+++ b/src/day8/re_frame/trace.cljs
@@ -199,11 +199,13 @@
                 (.toFixed duration 1) " ms"]]
               (when show-row?
                 [:tr {:key (str id "-details")}
-                 [:td {:col-span 3} (let [tag-str (with-out-str (pprint/pprint tags))
-                                          string-size-limit 400]
-                                      (if (< string-size-limit (count tag-str))
-                                        (str (subs tag-str 0 string-size-limit) " ...")
-                                        tag-str))]]))))))
+                 [:td.trace-details {:col-span 3
+                                     :on-click #(.log js/console (clj->js tags))}
+                   (let [tag-str (with-out-str (pprint/pprint tags))
+                         string-size-limit 400]
+                        (if (< string-size-limit (count tag-str))
+                          (str (subs tag-str 0 string-size-limit) " ...")
+                          tag-str))]]))))))
 
 (defn render-trace-panel []
   (let [filter-input               (r/atom "")


### PR DESCRIPTION
- fixes #56 
- print trace details to console on click so that it's easier to inspect