### PR TITLE
Isolate panel styles from host project

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,10 +117,20 @@ You need both the re-frame-trace project _and_ a test project to develop it agai
 
 ### Developing CSS
 
-The CSS for the trace panel are defined both inline and within `src/day8/re_frame/less`. To develop the styles, run
+The styles for the trace panel are defined both inline and in a LESS file. To develop the styles, edit `resources/day8/re_frame/trace/main.less` and run
 
 ```
 lein less auto
 ```
 
-and the .less file will automatically compile to css on file changes. Don't edit the file within `src/day8/re_frame/css` directly, or it will be overwriten. We are using css preprocessing because in order to isolate the panel styles, we are namespacing the panel styles with the id `#--re-frame-trace--`.
+to watch the LESS file and automatically recompile on changes.
+
+**Don't edit the CSS file `resources/day8/re_frame/trace/main.css` directly**, as it will be overwritten.
+
+We are using CSS preprocessing because in order to isolate the panel styles, we are namespacing the panel styles with the id `#--re-frame-trace--`.
+
+#### Problems while developing CSS
+
+- You may need to then save a `.cljs` file to trigger a figwheel reload.
+- Did you run `lein less auto` to compile LESS to CSS?
+- Try clearing your browser cache/hard-reloading

--- a/resources/day8/re_frame/trace/main.css
+++ b/resources/day8/re_frame/trace/main.css
@@ -76,7 +76,7 @@
 #--re-frame-trace-- textarea {
   font-family: "courier new", monospace;
   font-size: 100%;
-  line-height: 1.15;
+  padding: 3px 3px 1px 3px;
   border: 1px solid black;
 }
 #--re-frame-trace-- button,
@@ -250,6 +250,7 @@
   background: white;
   font-family: 'courier new', monospace;
   font-size: 1em;
+  padding: 2px 0 0 0;
   -moz-appearance: menulist;
   -webkit-appearance: menulist;
   appearance: menulist;

--- a/resources/day8/re_frame/trace/main.css
+++ b/resources/day8/re_frame/trace/main.css
@@ -1,7 +1,374 @@
 #--re-frame-trace-- {
+  all: initial;
+  /*! normalize.css v7.0.0 | MIT License | github.com/necolas/normalize.css */
+  /* Document
+     ========================================================================== */
+  /**
+   * 1. Correct the line height in all browsers.
+   * 2. Prevent adjustments of font size after orientation changes in
+   *    IE on Windows Phone and in iOS.
+   */
+  line-height: 1.15;
+  /* 1 */
+  -ms-text-size-adjust: 100%;
+  /* 2 */
+  -webkit-text-size-adjust: 100%;
+  /* 2 */
+  /* Sections
+     ========================================================================== */
+  /**
+   * Add the correct display in IE 9-.
+   */
+  /**
+   * Correct the font size and margin on `h1` elements within `section` and
+   * `article` contexts in Chrome, Firefox, and Safari.
+   */
+  /**
+   * 1. Correct the inheritance and scaling of font size in all browsers.
+   * 2. Correct the odd `em` font sizing in all browsers.
+   */
+  /* Text-level semantics
+     ========================================================================== */
+  /**
+   * 1. Remove the gray background on active links in IE 10.
+   * 2. Remove gaps in links underline in iOS 8+ and Safari 8+.
+   */
+  /**
+   * Prevent the duplicate application of `bolder` by the next rule in Safari 6.
+   */
+  /**
+   * Add the correct font weight in Chrome, Edge, and Safari.
+   */
+  /**
+   * 1. Correct the inheritance and scaling of font size in all browsers.
+   * 2. Correct the odd `em` font sizing in all browsers.
+   */
+  /**
+   * Add the correct background and color in IE 9-.
+   */
+  /**
+   * Add the correct font size in all browsers.
+   */
+  /**
+   * Prevent `sub` and `sup` elements from affecting the line height in
+   * all browsers.
+   */
+  /* Embedded content
+     ========================================================================== */
+  /**
+   * Add the correct display in IE 9-.
+   */
+  /**
+   * Add the correct display in iOS 4-7.
+   */
+  /**
+   * Remove the border on images inside links in IE 10-.
+   */
+  /**
+   * Hide the overflow in IE.
+   */
+  /* Forms
+     ========================================================================== */
+  /**
+   * 1. Change the font styles in all browsers (opinionated).
+   * 2. Remove the margin in Firefox and Safari.
+   */
+  /**
+   * Show the overflow in IE.
+   * 1. Show the overflow in Edge.
+   */
+  /**
+   * Remove the inheritance of text transform in Edge, Firefox, and IE.
+   * 1. Remove the inheritance of text transform in Firefox.
+   */
+  /**
+   * 1. Prevent a WebKit bug where (2) destroys native `audio` and `video`
+   *    controls in Android 4.
+   * 2. Correct the inability to style clickable types in iOS and Safari.
+   */
+  /**
+   * Remove the inner border and padding in Firefox.
+   */
+  /**
+   * Restore the focus styles unset by the previous rule.
+   */
+  /**
+   * Remove the default vertical scrollbar in IE.
+   */
+  /**
+   * 1. Add the correct box sizing in IE 10-.
+   * 2. Remove the padding in IE 10-.
+   */
+  /**
+   * Correct the cursor style of increment and decrement buttons in Chrome.
+   */
+  /**
+   * 1. Correct the odd appearance in Chrome and Safari.
+   * 2. Correct the outline style in Safari.
+   */
+  /**
+   * Remove the inner padding and cancel buttons in Chrome and Safari on macOS.
+   */
+  /**
+   * 1. Correct the inability to style clickable types in iOS and Safari.
+   * 2. Change font properties to `inherit` in Safari.
+   */
+  /* Hidden
+     ========================================================================== */
+  /**
+   * Add the correct display in IE 10-.
+   */
+  /* re-frame-trace styles
+     ========================================================================== */
   background: white;
-  color: black;
   font-family: 'courier new', monospace;
+}
+#--re-frame-trace-- * {
+  all: unset;
+}
+#--re-frame-trace-- div,
+#--re-frame-trace-- footer,
+#--re-frame-trace-- header,
+#--re-frame-trace-- nav {
+  display: block;
+}
+#--re-frame-trace-- h1 {
+  font-size: 2em;
+  margin: 0.67em 0;
+}
+#--re-frame-trace-- pre {
+  font-family: monospace, monospace;
+  /* 1 */
+  font-size: 1em;
+  /* 2 */
+}
+#--re-frame-trace-- a {
+  background-color: transparent;
+  /* 1 */
+  -webkit-text-decoration-skip: objects;
+  /* 2 */
+}
+#--re-frame-trace-- b,
+#--re-frame-trace-- strong {
+  font-weight: inherit;
+}
+#--re-frame-trace-- b,
+#--re-frame-trace-- strong {
+  font-weight: bolder;
+}
+#--re-frame-trace-- code {
+  font-family: monospace, monospace;
+  /* 1 */
+  font-size: 1em;
+  /* 2 */
+}
+#--re-frame-trace-- mark {
+  background-color: #ff0;
+  color: #000;
+}
+#--re-frame-trace-- small {
+  font-size: 80%;
+}
+#--re-frame-trace-- sub,
+#--re-frame-trace-- sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+#--re-frame-trace-- sub {
+  bottom: -0.25em;
+}
+#--re-frame-trace-- sup {
+  top: -0.5em;
+}
+#--re-frame-trace-- audio,
+#--re-frame-trace-- video {
+  display: inline-block;
+}
+#--re-frame-trace-- audio:not([controls]) {
+  display: none;
+  height: 0;
+}
+#--re-frame-trace-- img {
+  border-style: none;
+}
+#--re-frame-trace-- svg:not(:root) {
+  overflow: hidden;
+}
+#--re-frame-trace-- option {
+  display: block;
+}
+#--re-frame-trace-- button,
+#--re-frame-trace-- input,
+#--re-frame-trace-- optgroup,
+#--re-frame-trace-- select,
+#--re-frame-trace-- textarea {
+  font-family: sans-serif;
+  /* 1 */
+  font-size: 100%;
+  /* 1 */
+  line-height: 1.15;
+  /* 1 */
+  margin: 0;
+  /* 2 */
+  border: 1px solid black;
+}
+#--re-frame-trace-- button,
+#--re-frame-trace-- input {
+  /* 1 */
+  overflow: visible;
+}
+#--re-frame-trace-- button,
+#--re-frame-trace-- select {
+  /* 1 */
+  text-transform: none;
+}
+#--re-frame-trace-- button,
+#--re-frame-trace-- html [type="button"],
+#--re-frame-trace-- [type="reset"],
+#--re-frame-trace-- [type="submit"] {
+  -webkit-appearance: button;
+  /* 2 */
+}
+#--re-frame-trace-- button::-moz-focus-inner,
+#--re-frame-trace-- [type="button"]::-moz-focus-inner,
+#--re-frame-trace-- [type="reset"]::-moz-focus-inner,
+#--re-frame-trace-- [type="submit"]::-moz-focus-inner {
+  border-style: none;
+  padding: 0;
+}
+#--re-frame-trace-- button:-moz-focusring,
+#--re-frame-trace-- [type="button"]:-moz-focusring,
+#--re-frame-trace-- [type="reset"]:-moz-focusring,
+#--re-frame-trace-- [type="submit"]:-moz-focusring {
+  outline: 1px dotted ButtonText;
+}
+#--re-frame-trace-- textarea {
+  overflow: auto;
+}
+#--re-frame-trace-- [type="checkbox"],
+#--re-frame-trace-- [type="radio"] {
+  box-sizing: border-box;
+  /* 1 */
+  padding: 0;
+  /* 2 */
+}
+#--re-frame-trace-- [type="number"]::-webkit-inner-spin-button,
+#--re-frame-trace-- [type="number"]::-webkit-outer-spin-button {
+  height: auto;
+}
+#--re-frame-trace-- [type="search"] {
+  -webkit-appearance: textfield;
+  /* 1 */
+  outline-offset: -2px;
+  /* 2 */
+}
+#--re-frame-trace-- [type="search"]::-webkit-search-cancel-button,
+#--re-frame-trace-- [type="search"]::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+#--re-frame-trace-- ::-webkit-file-upload-button {
+  -webkit-appearance: button;
+  /* 1 */
+  font: inherit;
+  /* 2 */
+}
+#--re-frame-trace-- [hidden] {
+  display: none;
+}
+#--re-frame-trace-- h1,
+#--re-frame-trace-- h2,
+#--re-frame-trace-- h3,
+#--re-frame-trace-- h4,
+#--re-frame-trace-- p,
+#--re-frame-trace-- blockquote,
+#--re-frame-trace-- figure,
+#--re-frame-trace-- ol,
+#--re-frame-trace-- ul {
+  margin: 0;
+  padding: 0;
+}
+#--re-frame-trace-- main,
+#--re-frame-trace-- li {
+  display: block;
+}
+#--re-frame-trace-- h1,
+#--re-frame-trace-- h2,
+#--re-frame-trace-- h3,
+#--re-frame-trace-- h4 {
+  font-size: inherit;
+}
+#--re-frame-trace-- strong {
+  font-weight: bold;
+}
+#--re-frame-trace-- a,
+#--re-frame-trace-- button {
+  color: inherit;
+  transition: .3s;
+}
+#--re-frame-trace-- a {
+  text-decoration: none;
+}
+#--re-frame-trace-- button {
+  overflow: visible;
+  border: 0;
+  font: inherit;
+  -webkit-font-smoothing: inherit;
+  letter-spacing: inherit;
+  background: none;
+  cursor: pointer;
+}
+#--re-frame-trace-- ::-moz-focus-inner {
+  padding: 0;
+  border: 0;
+}
+#--re-frame-trace-- :focus {
+  outline: 0;
+}
+#--re-frame-trace-- img {
+  max-width: 100%;
+  height: auto;
+  border: 0;
+}
+#--re-frame-trace-- table,
+#--re-frame-trace-- thead,
+#--re-frame-trace-- tbody,
+#--re-frame-trace-- tfoot,
+#--re-frame-trace-- tr,
+#--re-frame-trace-- th,
+#--re-frame-trace-- td {
+  display: block;
+  width: auto;
+  height: auto;
+  margin: 0;
+  padding: 0;
+  border: none;
+  border-collapse: collapse;
+  border-spacing: 0;
+  border-color: inherit;
+  vertical-align: inherit;
+  text-align: left;
+  font-weight: inherit;
+  -webkit-border-horizontal-spacing: 0;
+  -webkit-border-vertical-spacing: 0;
+}
+#--re-frame-trace-- th,
+#--re-frame-trace-- td {
+  display: table-cell;
+}
+#--re-frame-trace-- tr {
+  display: table-row;
+}
+#--re-frame-trace-- thead {
+  display: table-header-group;
+}
+#--re-frame-trace-- tbody {
+  display: table-row-group;
+}
+#--re-frame-trace-- table {
+  display: table;
+  width: 100%;
 }
 #--re-frame-trace-- tbody {
   color: #aaa;

--- a/resources/day8/re_frame/trace/main.css
+++ b/resources/day8/re_frame/trace/main.css
@@ -158,6 +158,7 @@
 #--re-frame-trace-- th,
 #--re-frame-trace-- td {
   display: table-cell;
+  padding: 0 5px;
 }
 #--re-frame-trace-- tr {
   display: table-row;
@@ -263,7 +264,7 @@
   flex: 1;
 }
 #--re-frame-trace-- .panel-content-scrollable {
-  margin: 10px 0 0 10px;
+  margin: 0 10px;
   flex: 1 0 auto;
   height: 100%;
   overflow: auto;

--- a/resources/day8/re_frame/trace/main.css
+++ b/resources/day8/re_frame/trace/main.css
@@ -1,117 +1,17 @@
 #--re-frame-trace-- {
   all: initial;
-  /*! normalize.css v7.0.0 | MIT License | github.com/necolas/normalize.css */
-  /* Document
-     ========================================================================== */
-  /**
-   * 1. Correct the line height in all browsers.
-   * 2. Prevent adjustments of font size after orientation changes in
-   *    IE on Windows Phone and in iOS.
-   */
+  /*! abridged from normalize.css v7.0.0 | MIT License | github.com/necolas/normalize.css */
   line-height: 1.15;
-  /* 1 */
-  -ms-text-size-adjust: 100%;
-  /* 2 */
-  -webkit-text-size-adjust: 100%;
-  /* 2 */
-  /* Sections
-     ========================================================================== */
-  /**
-   * Add the correct display in IE 9-.
-   */
-  /**
-   * Correct the font size and margin on `h1` elements within `section` and
-   * `article` contexts in Chrome, Firefox, and Safari.
-   */
-  /**
-   * 1. Correct the inheritance and scaling of font size in all browsers.
-   * 2. Correct the odd `em` font sizing in all browsers.
-   */
   /* Text-level semantics
      ========================================================================== */
-  /**
-   * 1. Remove the gray background on active links in IE 10.
-   * 2. Remove gaps in links underline in iOS 8+ and Safari 8+.
-   */
-  /**
-   * Prevent the duplicate application of `bolder` by the next rule in Safari 6.
-   */
-  /**
-   * Add the correct font weight in Chrome, Edge, and Safari.
-   */
-  /**
-   * 1. Correct the inheritance and scaling of font size in all browsers.
-   * 2. Correct the odd `em` font sizing in all browsers.
-   */
-  /**
-   * Add the correct background and color in IE 9-.
-   */
-  /**
-   * Add the correct font size in all browsers.
-   */
-  /**
-   * Prevent `sub` and `sup` elements from affecting the line height in
-   * all browsers.
-   */
   /* Embedded content
      ========================================================================== */
-  /**
-   * Add the correct display in IE 9-.
-   */
-  /**
-   * Add the correct display in iOS 4-7.
-   */
-  /**
-   * Remove the border on images inside links in IE 10-.
-   */
-  /**
-   * Hide the overflow in IE.
-   */
   /* Forms
      ========================================================================== */
-  /**
-   * 1. Change the font styles in all browsers (opinionated).
-   * 2. Remove the margin in Firefox and Safari.
-   */
-  /**
-   * Show the overflow in IE.
-   * 1. Show the overflow in Edge.
-   */
-  /**
-   * Remove the inheritance of text transform in Edge, Firefox, and IE.
-   * 1. Remove the inheritance of text transform in Firefox.
-   */
   /**
    * 1. Prevent a WebKit bug where (2) destroys native `audio` and `video`
    *    controls in Android 4.
    * 2. Correct the inability to style clickable types in iOS and Safari.
-   */
-  /**
-   * Remove the inner border and padding in Firefox.
-   */
-  /**
-   * Restore the focus styles unset by the previous rule.
-   */
-  /**
-   * Remove the default vertical scrollbar in IE.
-   */
-  /**
-   * 1. Add the correct box sizing in IE 10-.
-   * 2. Remove the padding in IE 10-.
-   */
-  /**
-   * Correct the cursor style of increment and decrement buttons in Chrome.
-   */
-  /**
-   * 1. Correct the odd appearance in Chrome and Safari.
-   * 2. Correct the outline style in Safari.
-   */
-  /**
-   * Remove the inner padding and cancel buttons in Chrome and Safari on macOS.
-   */
-  /**
-   * 1. Correct the inability to style clickable types in iOS and Safari.
-   * 2. Change font properties to `inherit` in Safari.
    */
   /* Hidden
      ========================================================================== */
@@ -127,44 +27,25 @@
   all: unset;
 }
 #--re-frame-trace-- div,
-#--re-frame-trace-- footer,
-#--re-frame-trace-- header,
 #--re-frame-trace-- nav {
   display: block;
 }
-#--re-frame-trace-- h1 {
-  font-size: 2em;
-  margin: 0.67em 0;
-}
 #--re-frame-trace-- pre {
   font-family: monospace, monospace;
-  /* 1 */
   font-size: 1em;
-  /* 2 */
 }
-#--re-frame-trace-- a {
-  background-color: transparent;
-  /* 1 */
-  -webkit-text-decoration-skip: objects;
-  /* 2 */
+#--re-frame-trace-- a,
+#--re-frame-trace-- a:visited {
+  color: #333;
+  border-bottom: 1px #333 dotted;
 }
-#--re-frame-trace-- b,
-#--re-frame-trace-- strong {
-  font-weight: inherit;
-}
-#--re-frame-trace-- b,
-#--re-frame-trace-- strong {
-  font-weight: bolder;
+#--re-frame-trace-- a:hover,
+#--re-frame-trace-- a:focus {
+  border-bottom: 1px #666666 solid;
 }
 #--re-frame-trace-- code {
   font-family: monospace, monospace;
-  /* 1 */
   font-size: 1em;
-  /* 2 */
-}
-#--re-frame-trace-- mark {
-  background-color: #ff0;
-  color: #000;
 }
 #--re-frame-trace-- small {
   font-size: 80%;
@@ -182,19 +63,8 @@
 #--re-frame-trace-- sup {
   top: -0.5em;
 }
-#--re-frame-trace-- audio,
-#--re-frame-trace-- video {
-  display: inline-block;
-}
-#--re-frame-trace-- audio:not([controls]) {
-  display: none;
-  height: 0;
-}
 #--re-frame-trace-- img {
   border-style: none;
-}
-#--re-frame-trace-- svg:not(:root) {
-  overflow: hidden;
 }
 #--re-frame-trace-- option {
   display: block;
@@ -204,25 +74,14 @@
 #--re-frame-trace-- optgroup,
 #--re-frame-trace-- select,
 #--re-frame-trace-- textarea {
-  font-family: sans-serif;
-  /* 1 */
+  font-family: "courier new", monospace;
   font-size: 100%;
-  /* 1 */
   line-height: 1.15;
-  /* 1 */
-  margin: 0;
-  /* 2 */
   border: 1px solid black;
 }
 #--re-frame-trace-- button,
 #--re-frame-trace-- input {
-  /* 1 */
   overflow: visible;
-}
-#--re-frame-trace-- button,
-#--re-frame-trace-- select {
-  /* 1 */
-  text-transform: none;
 }
 #--re-frame-trace-- button,
 #--re-frame-trace-- html [type="button"],
@@ -230,13 +89,6 @@
 #--re-frame-trace-- [type="submit"] {
   -webkit-appearance: button;
   /* 2 */
-}
-#--re-frame-trace-- button::-moz-focus-inner,
-#--re-frame-trace-- [type="button"]::-moz-focus-inner,
-#--re-frame-trace-- [type="reset"]::-moz-focus-inner,
-#--re-frame-trace-- [type="submit"]::-moz-focus-inner {
-  border-style: none;
-  padding: 0;
 }
 #--re-frame-trace-- button:-moz-focusring,
 #--re-frame-trace-- [type="button"]:-moz-focusring,
@@ -250,9 +102,6 @@
 #--re-frame-trace-- [type="checkbox"],
 #--re-frame-trace-- [type="radio"] {
   box-sizing: border-box;
-  /* 1 */
-  padding: 0;
-  /* 2 */
 }
 #--re-frame-trace-- [type="number"]::-webkit-inner-spin-button,
 #--re-frame-trace-- [type="number"]::-webkit-outer-spin-button {
@@ -260,71 +109,24 @@
 }
 #--re-frame-trace-- [type="search"] {
   -webkit-appearance: textfield;
-  /* 1 */
   outline-offset: -2px;
-  /* 2 */
-}
-#--re-frame-trace-- [type="search"]::-webkit-search-cancel-button,
-#--re-frame-trace-- [type="search"]::-webkit-search-decoration {
-  -webkit-appearance: none;
 }
 #--re-frame-trace-- ::-webkit-file-upload-button {
   -webkit-appearance: button;
-  /* 1 */
-  font: inherit;
-  /* 2 */
 }
 #--re-frame-trace-- [hidden] {
   display: none;
 }
-#--re-frame-trace-- h1,
-#--re-frame-trace-- h2,
-#--re-frame-trace-- h3,
-#--re-frame-trace-- h4,
-#--re-frame-trace-- p,
-#--re-frame-trace-- blockquote,
-#--re-frame-trace-- figure,
-#--re-frame-trace-- ol,
-#--re-frame-trace-- ul {
-  margin: 0;
-  padding: 0;
-}
-#--re-frame-trace-- main,
 #--re-frame-trace-- li {
   display: block;
-}
-#--re-frame-trace-- h1,
-#--re-frame-trace-- h2,
-#--re-frame-trace-- h3,
-#--re-frame-trace-- h4 {
-  font-size: inherit;
-}
-#--re-frame-trace-- strong {
-  font-weight: bold;
-}
-#--re-frame-trace-- a,
-#--re-frame-trace-- button {
-  color: inherit;
-  transition: .3s;
-}
-#--re-frame-trace-- a {
-  text-decoration: none;
 }
 #--re-frame-trace-- button {
   overflow: visible;
   border: 0;
-  font: inherit;
   -webkit-font-smoothing: inherit;
   letter-spacing: inherit;
   background: none;
   cursor: pointer;
-}
-#--re-frame-trace-- ::-moz-focus-inner {
-  padding: 0;
-  border: 0;
-}
-#--re-frame-trace-- :focus {
-  outline: 0;
 }
 #--re-frame-trace-- img {
   max-width: 100%;
@@ -448,6 +250,9 @@
   background: white;
   font-family: 'courier new', monospace;
   font-size: 1em;
+  -moz-appearance: menulist;
+  -webkit-appearance: menulist;
+  appearance: menulist;
 }
 #--re-frame-trace-- .nav {
   background: #efeef1;

--- a/resources/day8/re_frame/trace/main.less
+++ b/resources/day8/re_frame/trace/main.less
@@ -1,6 +1,430 @@
 #--re-frame-trace-- {
+
+  all: initial;
+
+  * {
+    all: unset;
+  }
+
+  /*! normalize.css v7.0.0 | MIT License | github.com/necolas/normalize.css */
+
+  /* Document
+     ========================================================================== */
+
+  /**
+   * 1. Correct the line height in all browsers.
+   * 2. Prevent adjustments of font size after orientation changes in
+   *    IE on Windows Phone and in iOS.
+   */
+
+  // html {
+  line-height: 1.15; /* 1 */
+  -ms-text-size-adjust: 100%; /* 2 */
+  -webkit-text-size-adjust: 100%; /* 2 */
+  // }
+
+  /* Sections
+     ========================================================================== */
+
+  /**
+   * Add the correct display in IE 9-.
+   */
+
+  div,
+  footer,
+  header,
+  nav {
+    display: block;
+  }
+
+  /**
+   * Correct the font size and margin on `h1` elements within `section` and
+   * `article` contexts in Chrome, Firefox, and Safari.
+   */
+
+  h1 {
+    font-size: 2em;
+    margin: 0.67em 0;
+  }
+
+  /**
+   * 1. Correct the inheritance and scaling of font size in all browsers.
+   * 2. Correct the odd `em` font sizing in all browsers.
+   */
+
+  pre {
+    font-family: monospace, monospace; /* 1 */
+    font-size: 1em; /* 2 */
+  }
+
+  /* Text-level semantics
+     ========================================================================== */
+
+  /**
+   * 1. Remove the gray background on active links in IE 10.
+   * 2. Remove gaps in links underline in iOS 8+ and Safari 8+.
+   */
+
+  a {
+    background-color: transparent; /* 1 */
+    -webkit-text-decoration-skip: objects; /* 2 */
+  }
+
+  /**
+   * Prevent the duplicate application of `bolder` by the next rule in Safari 6.
+   */
+
+  b,
+  strong {
+    font-weight: inherit;
+  }
+
+  /**
+   * Add the correct font weight in Chrome, Edge, and Safari.
+   */
+
+  b,
+  strong {
+    font-weight: bolder;
+  }
+
+  /**
+   * 1. Correct the inheritance and scaling of font size in all browsers.
+   * 2. Correct the odd `em` font sizing in all browsers.
+   */
+
+  code {
+    font-family: monospace, monospace; /* 1 */
+    font-size: 1em; /* 2 */
+  }
+
+  /**
+   * Add the correct background and color in IE 9-.
+   */
+
+  mark {
+    background-color: #ff0;
+    color: #000;
+  }
+
+  /**
+   * Add the correct font size in all browsers.
+   */
+
+  small {
+    font-size: 80%;
+  }
+
+  /**
+   * Prevent `sub` and `sup` elements from affecting the line height in
+   * all browsers.
+   */
+
+  sub,
+  sup {
+    font-size: 75%;
+    line-height: 0;
+    position: relative;
+    vertical-align: baseline;
+  }
+
+  sub {
+    bottom: -0.25em;
+  }
+
+  sup {
+    top: -0.5em;
+  }
+
+  /* Embedded content
+     ========================================================================== */
+
+  /**
+   * Add the correct display in IE 9-.
+   */
+
+  audio,
+  video {
+    display: inline-block;
+  }
+
+  /**
+   * Add the correct display in iOS 4-7.
+   */
+
+  audio:not([controls]) {
+    display: none;
+    height: 0;
+  }
+
+  /**
+   * Remove the border on images inside links in IE 10-.
+   */
+
+  img {
+    border-style: none;
+  }
+
+  /**
+   * Hide the overflow in IE.
+   */
+
+  svg:not(:root) {
+    overflow: hidden;
+  }
+
+  /* Forms
+     ========================================================================== */
+
+  option {
+    display: block;
+  }
+
+  /**
+   * 1. Change the font styles in all browsers (opinionated).
+   * 2. Remove the margin in Firefox and Safari.
+   */
+
+  button,
+  input,
+  optgroup,
+  select,
+  textarea {
+    font-family: sans-serif; /* 1 */
+    font-size: 100%; /* 1 */
+    line-height: 1.15; /* 1 */
+    margin: 0; /* 2 */
+    border: 1px solid black;
+    // background-color: transparent;
+  }
+
+  /**
+   * Show the overflow in IE.
+   * 1. Show the overflow in Edge.
+   */
+
+  button,
+  input { /* 1 */
+    overflow: visible;
+  }
+
+  /**
+   * Remove the inheritance of text transform in Edge, Firefox, and IE.
+   * 1. Remove the inheritance of text transform in Firefox.
+   */
+
+  button,
+  select { /* 1 */
+    text-transform: none;
+  }
+
+  /**
+   * 1. Prevent a WebKit bug where (2) destroys native `audio` and `video`
+   *    controls in Android 4.
+   * 2. Correct the inability to style clickable types in iOS and Safari.
+   */
+
+  button,
+  html [type="button"], /* 1 */
+  [type="reset"],
+  [type="submit"] {
+    -webkit-appearance: button; /* 2 */
+  }
+
+  /**
+   * Remove the inner border and padding in Firefox.
+   */
+
+  button::-moz-focus-inner,
+  [type="button"]::-moz-focus-inner,
+  [type="reset"]::-moz-focus-inner,
+  [type="submit"]::-moz-focus-inner {
+    border-style: none;
+    padding: 0;
+  }
+
+  /**
+   * Restore the focus styles unset by the previous rule.
+   */
+
+  button:-moz-focusring,
+  [type="button"]:-moz-focusring,
+  [type="reset"]:-moz-focusring,
+  [type="submit"]:-moz-focusring {
+    outline: 1px dotted ButtonText;
+  }
+
+  /**
+   * Remove the default vertical scrollbar in IE.
+   */
+
+  textarea {
+    overflow: auto;
+  }
+
+  /**
+   * 1. Add the correct box sizing in IE 10-.
+   * 2. Remove the padding in IE 10-.
+   */
+
+  [type="checkbox"],
+  [type="radio"] {
+    box-sizing: border-box; /* 1 */
+    padding: 0; /* 2 */
+  }
+
+  /**
+   * Correct the cursor style of increment and decrement buttons in Chrome.
+   */
+
+  [type="number"]::-webkit-inner-spin-button,
+  [type="number"]::-webkit-outer-spin-button {
+    height: auto;
+  }
+
+  /**
+   * 1. Correct the odd appearance in Chrome and Safari.
+   * 2. Correct the outline style in Safari.
+   */
+
+  [type="search"] {
+    -webkit-appearance: textfield; /* 1 */
+    outline-offset: -2px; /* 2 */
+  }
+
+  /**
+   * Remove the inner padding and cancel buttons in Chrome and Safari on macOS.
+   */
+
+  [type="search"]::-webkit-search-cancel-button,
+  [type="search"]::-webkit-search-decoration {
+    -webkit-appearance: none;
+  }
+
+  /**
+   * 1. Correct the inability to style clickable types in iOS and Safari.
+   * 2. Change font properties to `inherit` in Safari.
+   */
+
+  ::-webkit-file-upload-button {
+    -webkit-appearance: button; /* 1 */
+    font: inherit; /* 2 */
+  }
+
+
+  /* Hidden
+     ========================================================================== */
+
+  /**
+   * Add the correct display in IE 10-.
+   */
+
+  [hidden] {
+    display: none;
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  p,
+  blockquote,
+  figure,
+  ol,
+  ul {
+      margin: 0;
+      padding: 0;
+  }
+  main,
+  li {
+      display: block;
+  }
+  h1,
+  h2,
+  h3,
+  h4 {
+      font-size: inherit;
+  }
+  strong {
+      font-weight: bold;
+  }
+  a,
+  button {
+      color: inherit;
+      transition: .3s;
+  }
+  a {
+      text-decoration: none;
+  }
+  button {
+      overflow: visible;
+      border: 0;
+      font: inherit;
+      -webkit-font-smoothing: inherit;
+      letter-spacing: inherit;
+      background: none;
+      cursor: pointer;
+  }
+  ::-moz-focus-inner {
+      padding: 0;
+      border: 0;
+  }
+  :focus {
+      outline: 0;
+  }
+  img {
+      max-width: 100%;
+      height: auto;
+      border: 0;
+  }
+
+// tables
+
+table,
+thead,
+tbody,
+tfoot,
+tr,
+th,
+td {
+    display: block;
+    width: auto;
+    height: auto;
+    margin: 0;
+    padding: 0;
+    border: none;
+    border-collapse: collapse;
+    border-spacing: 0;
+    border-color: inherit;
+    vertical-align: inherit;
+    text-align: left;
+    font-weight: inherit;
+    -webkit-border-horizontal-spacing: 0;
+    -webkit-border-vertical-spacing: 0;
+}
+th, td {
+  display: table-cell;
+}
+tr {
+  display: table-row;
+}
+thead {
+  display: table-header-group;
+}
+tbody {
+  display: table-row-group;
+}
+table {
+  display: table;
+  width: 100%;
+}
+
+
+  /* re-frame-trace styles
+     ========================================================================== */
+
+
   background: white;
-  color: black;
   font-family: 'courier new', monospace;
 
   tbody {

--- a/resources/day8/re_frame/trace/main.less
+++ b/resources/day8/re_frame/trace/main.less
@@ -189,6 +189,7 @@
   }
   th, td {
     display: table-cell;
+    padding: 0 5px;
   }
   tr {
     display: table-row;
@@ -310,7 +311,7 @@
     flex: 1;
   }
   .panel-content-scrollable {
-    margin: 10px 0 0 10px;
+    margin: 0 10px;
     flex: 1 0 auto;
     height: 100%;
     overflow: auto;

--- a/resources/day8/re_frame/trace/main.less
+++ b/resources/day8/re_frame/trace/main.less
@@ -79,7 +79,8 @@
   textarea {
     font-family: "courier new", monospace;
     font-size: 100%;
-    line-height: 1.15;
+    // line-height: 1.15;
+    padding: 3px 3px 1px 3px;
     border: 1px solid black;
   }
 
@@ -296,28 +297,11 @@
     background: white;
     font-family: 'courier new', monospace;
     font-size: 1em;
+    padding: 2px 0 0 0;
     -moz-appearance: menulist;
     -webkit-appearance: menulist;
     appearance: menulist;
   }
-  // select {
-  //   background-image:
-  //     linear-gradient(45deg, transparent 50%, gray 50%),
-  //     linear-gradient(135deg, gray 50%, transparent 50%);
-  //   background-position:
-  //     calc(100% - 10px) calc(1em + 2px),
-  //     calc(100% - 5px) calc(1em + 2px);
-  //   background-size:
-  //     5px 5px,
-  //     5px 5px,
-  //     1px 1.5em;
-  //   background-repeat: no-repeat;
-  // }
-  // select:-moz-focusring {
-  //   color: transparent;
-  //   text-shadow: 0 0 0 #000;
-  // }
-
   .nav {
     background: #efeef1;
     color: #222;

--- a/resources/day8/re_frame/trace/main.less
+++ b/resources/day8/re_frame/trace/main.less
@@ -6,120 +6,41 @@
     all: unset;
   }
 
-  /*! normalize.css v7.0.0 | MIT License | github.com/necolas/normalize.css */
+  /*! abridged from normalize.css v7.0.0 | MIT License | github.com/necolas/normalize.css */
 
-  /* Document
-     ========================================================================== */
-
-  /**
-   * 1. Correct the line height in all browsers.
-   * 2. Prevent adjustments of font size after orientation changes in
-   *    IE on Windows Phone and in iOS.
-   */
-
-  // html {
-  line-height: 1.15; /* 1 */
-  -ms-text-size-adjust: 100%; /* 2 */
-  -webkit-text-size-adjust: 100%; /* 2 */
-  // }
-
-  /* Sections
-     ========================================================================== */
-
-  /**
-   * Add the correct display in IE 9-.
-   */
+  line-height: 1.15;
 
   div,
-  footer,
-  header,
   nav {
     display: block;
   }
 
-  /**
-   * Correct the font size and margin on `h1` elements within `section` and
-   * `article` contexts in Chrome, Firefox, and Safari.
-   */
-
-  h1 {
-    font-size: 2em;
-    margin: 0.67em 0;
-  }
-
-  /**
-   * 1. Correct the inheritance and scaling of font size in all browsers.
-   * 2. Correct the odd `em` font sizing in all browsers.
-   */
-
   pre {
-    font-family: monospace, monospace; /* 1 */
-    font-size: 1em; /* 2 */
+    font-family: monospace, monospace;
+    font-size: 1em;
   }
 
   /* Text-level semantics
      ========================================================================== */
 
-  /**
-   * 1. Remove the gray background on active links in IE 10.
-   * 2. Remove gaps in links underline in iOS 8+ and Safari 8+.
-   */
-
-  a {
-    background-color: transparent; /* 1 */
-    -webkit-text-decoration-skip: objects; /* 2 */
+  a, a:visited {
+    color: #333;
+    border-bottom: 1px #333 dotted;
   }
-
-  /**
-   * Prevent the duplicate application of `bolder` by the next rule in Safari 6.
-   */
-
-  b,
-  strong {
-    font-weight: inherit;
+  a:hover, a:focus {
+    border-bottom: 1px #666666 solid;
   }
-
-  /**
-   * Add the correct font weight in Chrome, Edge, and Safari.
-   */
-
-  b,
-  strong {
-    font-weight: bolder;
-  }
-
-  /**
-   * 1. Correct the inheritance and scaling of font size in all browsers.
-   * 2. Correct the odd `em` font sizing in all browsers.
-   */
 
   code {
-    font-family: monospace, monospace; /* 1 */
-    font-size: 1em; /* 2 */
+    font-family: monospace, monospace;
+    font-size: 1em;
   }
-
-  /**
-   * Add the correct background and color in IE 9-.
-   */
-
-  mark {
-    background-color: #ff0;
-    color: #000;
-  }
-
-  /**
-   * Add the correct font size in all browsers.
-   */
 
   small {
     font-size: 80%;
   }
 
-  /**
-   * Prevent `sub` and `sup` elements from affecting the line height in
-   * all browsers.
-   */
-
+  // Prevent `sub` and `sup` elements from affecting the line height
   sub,
   sup {
     font-size: 75%;
@@ -139,39 +60,10 @@
   /* Embedded content
      ========================================================================== */
 
-  /**
-   * Add the correct display in IE 9-.
-   */
-
-  audio,
-  video {
-    display: inline-block;
-  }
-
-  /**
-   * Add the correct display in iOS 4-7.
-   */
-
-  audio:not([controls]) {
-    display: none;
-    height: 0;
-  }
-
-  /**
-   * Remove the border on images inside links in IE 10-.
-   */
-
   img {
     border-style: none;
   }
 
-  /**
-   * Hide the overflow in IE.
-   */
-
-  svg:not(:root) {
-    overflow: hidden;
-  }
 
   /* Forms
      ========================================================================== */
@@ -180,42 +72,20 @@
     display: block;
   }
 
-  /**
-   * 1. Change the font styles in all browsers (opinionated).
-   * 2. Remove the margin in Firefox and Safari.
-   */
-
   button,
   input,
   optgroup,
   select,
   textarea {
-    font-family: sans-serif; /* 1 */
-    font-size: 100%; /* 1 */
-    line-height: 1.15; /* 1 */
-    margin: 0; /* 2 */
+    font-family: "courier new", monospace;
+    font-size: 100%;
+    line-height: 1.15;
     border: 1px solid black;
-    // background-color: transparent;
   }
 
-  /**
-   * Show the overflow in IE.
-   * 1. Show the overflow in Edge.
-   */
-
-  button,
-  input { /* 1 */
+  button, // Show the overflow in IE.
+  input { // Show the overflow in Edge.
     overflow: visible;
-  }
-
-  /**
-   * Remove the inheritance of text transform in Edge, Firefox, and IE.
-   * 1. Remove the inheritance of text transform in Firefox.
-   */
-
-  button,
-  select { /* 1 */
-    text-transform: none;
   }
 
   /**
@@ -231,22 +101,7 @@
     -webkit-appearance: button; /* 2 */
   }
 
-  /**
-   * Remove the inner border and padding in Firefox.
-   */
-
-  button::-moz-focus-inner,
-  [type="button"]::-moz-focus-inner,
-  [type="reset"]::-moz-focus-inner,
-  [type="submit"]::-moz-focus-inner {
-    border-style: none;
-    padding: 0;
-  }
-
-  /**
-   * Restore the focus styles unset by the previous rule.
-   */
-
+  // Restore the focus styles unset by the previous rule.
   button:-moz-focusring,
   [type="button"]:-moz-focusring,
   [type="reset"]:-moz-focusring,
@@ -254,61 +109,28 @@
     outline: 1px dotted ButtonText;
   }
 
-  /**
-   * Remove the default vertical scrollbar in IE.
-   */
-
   textarea {
-    overflow: auto;
+    overflow: auto; // Remove the default vertical scrollbar in IE.
   }
-
-  /**
-   * 1. Add the correct box sizing in IE 10-.
-   * 2. Remove the padding in IE 10-.
-   */
 
   [type="checkbox"],
   [type="radio"] {
-    box-sizing: border-box; /* 1 */
-    padding: 0; /* 2 */
+    box-sizing: border-box; // IE 10-
   }
 
-  /**
-   * Correct the cursor style of increment and decrement buttons in Chrome.
-   */
-
+  // Correct the cursor style of increment and decrement buttons in Chrome.
   [type="number"]::-webkit-inner-spin-button,
   [type="number"]::-webkit-outer-spin-button {
     height: auto;
   }
 
-  /**
-   * 1. Correct the odd appearance in Chrome and Safari.
-   * 2. Correct the outline style in Safari.
-   */
-
   [type="search"] {
-    -webkit-appearance: textfield; /* 1 */
-    outline-offset: -2px; /* 2 */
+    -webkit-appearance: textfield; // Correct the odd appearance in Chrome and Safari.
+    outline-offset: -2px; // Correct the outline style in Safari.
   }
-
-  /**
-   * Remove the inner padding and cancel buttons in Chrome and Safari on macOS.
-   */
-
-  [type="search"]::-webkit-search-cancel-button,
-  [type="search"]::-webkit-search-decoration {
-    -webkit-appearance: none;
-  }
-
-  /**
-   * 1. Correct the inability to style clickable types in iOS and Safari.
-   * 2. Change font properties to `inherit` in Safari.
-   */
 
   ::-webkit-file-upload-button {
-    -webkit-appearance: button; /* 1 */
-    font: inherit; /* 2 */
+    -webkit-appearance: button; // Correct the inability to style clickable types in iOS and Safari.
   }
 
 
@@ -323,70 +145,32 @@
     display: none;
   }
 
-  h1,
-  h2,
-  h3,
-  h4,
-  p,
-  blockquote,
-  figure,
-  ol,
-  ul {
-      margin: 0;
-      padding: 0;
-  }
-  main,
   li {
-      display: block;
-  }
-  h1,
-  h2,
-  h3,
-  h4 {
-      font-size: inherit;
-  }
-  strong {
-      font-weight: bold;
-  }
-  a,
-  button {
-      color: inherit;
-      transition: .3s;
-  }
-  a {
-      text-decoration: none;
+    display: block;
   }
   button {
-      overflow: visible;
-      border: 0;
-      font: inherit;
-      -webkit-font-smoothing: inherit;
-      letter-spacing: inherit;
-      background: none;
-      cursor: pointer;
-  }
-  ::-moz-focus-inner {
-      padding: 0;
-      border: 0;
-  }
-  :focus {
-      outline: 0;
+    overflow: visible;
+    border: 0;
+    -webkit-font-smoothing: inherit;
+    letter-spacing: inherit;
+    background: none;
+    cursor: pointer;
   }
   img {
-      max-width: 100%;
-      height: auto;
-      border: 0;
+    max-width: 100%;
+    height: auto;
+    border: 0;
   }
 
-// tables
+  // tables
 
-table,
-thead,
-tbody,
-tfoot,
-tr,
-th,
-td {
+  table,
+  thead,
+  tbody,
+  tfoot,
+  tr,
+  th,
+  td {
     display: block;
     width: auto;
     height: auto;
@@ -401,23 +185,23 @@ td {
     font-weight: inherit;
     -webkit-border-horizontal-spacing: 0;
     -webkit-border-vertical-spacing: 0;
-}
-th, td {
-  display: table-cell;
-}
-tr {
-  display: table-row;
-}
-thead {
-  display: table-header-group;
-}
-tbody {
-  display: table-row-group;
-}
-table {
-  display: table;
-  width: 100%;
-}
+  }
+  th, td {
+    display: table-cell;
+  }
+  tr {
+    display: table-row;
+  }
+  thead {
+    display: table-header-group;
+  }
+  tbody {
+    display: table-row-group;
+  }
+  table {
+    display: table;
+    width: 100%;
+  }
 
 
   /* re-frame-trace styles
@@ -512,7 +296,28 @@ table {
     background: white;
     font-family: 'courier new', monospace;
     font-size: 1em;
+    -moz-appearance: menulist;
+    -webkit-appearance: menulist;
+    appearance: menulist;
   }
+  // select {
+  //   background-image:
+  //     linear-gradient(45deg, transparent 50%, gray 50%),
+  //     linear-gradient(135deg, gray 50%, transparent 50%);
+  //   background-position:
+  //     calc(100% - 10px) calc(1em + 2px),
+  //     calc(100% - 5px) calc(1em + 2px);
+  //   background-size:
+  //     5px 5px,
+  //     5px 5px,
+  //     1px 1.5em;
+  //   background-repeat: no-repeat;
+  // }
+  // select:-moz-focusring {
+  //   color: transparent;
+  //   text-shadow: 0 0 0 #000;
+  // }
+
   .nav {
     background: #efeef1;
     color: #222;

--- a/resources/day8/re_frame/trace/main.less
+++ b/resources/day8/re_frame/trace/main.less
@@ -1,3 +1,9 @@
+@light-purple: #616cdb;
+@light-blue: lightblue;
+@light-gray: #efeef1;
+@text-color: #222;
+@text-color-muted: #aaa;
+
 #--re-frame-trace-- {
 
   all: initial;
@@ -24,7 +30,7 @@
      ========================================================================== */
 
   a, a:visited {
-    color: #333;
+    color: @text-color;
     border-bottom: 1px #333 dotted;
   }
   a:hover, a:focus {
@@ -214,7 +220,7 @@
   font-family: 'courier new', monospace;
 
   tbody {
-    color: #aaa;
+    color: @text-color-muted;
   }
   tr:hover {
     transition: all 0.1s ease-out;
@@ -258,7 +264,7 @@
   }
   .tab.active {
     background: transparent;
-    border-bottom: 3px solid lightblue;
+    border-bottom: 3px solid @light-blue;
     border-radius: 0;
     padding-bottom: 1px;
   }
@@ -270,7 +276,7 @@
   }
   .filter-items li {
     color: #333;
-    background: #efefef;
+    background: @light-gray;
     display: inline-block;
     font-size: 0.9em;
     margin:  5px;
@@ -278,7 +284,7 @@
   .filter-items {
     li {
       .filter-item-string {
-        color: #616cdb;
+        color: @light-purple;
       }
     }
 
@@ -304,8 +310,8 @@
     appearance: menulist;
   }
   .nav {
-    background: #efeef1;
-    color: #222;
+    background: @light-gray;
+    color: @text-color;
   }
   .panel-content-top {
     flex: 1;

--- a/src/day8/re_frame/trace.cljs
+++ b/src/day8/re_frame/trace.cljs
@@ -164,8 +164,7 @@
 (defn render-traces [showing-traces filter-items filter-input trace-detail-expansions]
   (doall
     (for [{:keys [op-type id operation tags duration] :as trace} showing-traces]
-      (let [padding          {:padding "0px 5px 0px 5px"}
-            row-style        (merge padding {:border-top (case op-type :event "1px solid lightgrey" nil)})
+      (let [row-style        {:border-top (case op-type :event "1px solid lightgrey" nil)}
             show-row?        (get-in @trace-detail-expansions [:overrides id]
                                (:show-all? @trace-detail-expansions))
             op-name          (if (vector? operation)
@@ -207,14 +206,13 @@
                 (.toFixed duration 1) " ms"]]
               (when show-row?
                 [:tr {:key (str id "-details")}
-                 [:td.trace-details {:col-span 3
+                 [:td.trace-details {:col-span 4
                                      :on-click #(.log js/console tags)}
                    (let [tag-str (with-out-str (pprint/pprint tags))
                          string-size-limit 400]
                         (if (< string-size-limit (count tag-str))
                           (str (subs tag-str 0 string-size-limit) " ...")
                           tag-str))]]))))))
-
 (defn render-trace-panel []
   (let [filter-input               (r/atom "")
         filter-items               (r/atom (localstorage/get "filter-items" []))


### PR DESCRIPTION
I'm using 

```
 #--re-frame-trace-- {
 
   all: initial;
 
   * {
     all: unset;
   }

  ...
}
```

To reset all the styles within the trace panel, so the panel doesn't take on styles from its host project that make it unusable and weird-looking. Unfortunately, this also wipes out user agent styles, so this PR rebuilds the minimal styles necessary for the side panel to function.

(note: main.css is generated from main.less, so only main.less needs to be reviewed).

Closes #17, #44 