### PR TITLE
app-state tab

### DIFF
--- a/resources/day8/re_frame/trace/main.css
+++ b/resources/day8/re_frame/trace/main.css
@@ -36,7 +36,7 @@
 }
 #--re-frame-trace-- a,
 #--re-frame-trace-- a:visited {
-  color: #333;
+  color: #222222;
   border-bottom: 1px #333 dotted;
 }
 #--re-frame-trace-- a:hover,
@@ -158,6 +158,7 @@
 #--re-frame-trace-- th,
 #--re-frame-trace-- td {
   display: table-cell;
+  padding: 0 5px;
 }
 #--re-frame-trace-- tr {
   display: table-row;
@@ -173,7 +174,7 @@
   width: 100%;
 }
 #--re-frame-trace-- tbody {
-  color: #aaa;
+  color: #aaaaaa;
 }
 #--re-frame-trace-- tr:hover {
   transition: all 0.1s ease-out;
@@ -215,7 +216,7 @@
 }
 #--re-frame-trace-- .tab.active {
   background: transparent;
-  border-bottom: 3px solid lightblue;
+  border-bottom: 3px solid #add8e6;
   border-radius: 0;
   padding-bottom: 1px;
 }
@@ -227,7 +228,7 @@
 }
 #--re-frame-trace-- .filter-items li {
   color: #333;
-  background: #efefef;
+  background: #efeef1;
   display: inline-block;
   font-size: 0.9em;
   margin: 5px;
@@ -257,13 +258,13 @@
 }
 #--re-frame-trace-- .nav {
   background: #efeef1;
-  color: #222;
+  color: #222222;
 }
 #--re-frame-trace-- .panel-content-top {
   flex: 1;
 }
 #--re-frame-trace-- .panel-content-scrollable {
-  margin: 10px 0 0 10px;
+  margin: 0 10px;
   flex: 1 0 auto;
   height: 100%;
   overflow: auto;

--- a/resources/day8/re_frame/trace/main.css
+++ b/resources/day8/re_frame/trace/main.css
@@ -22,6 +22,9 @@
      ========================================================================== */
   background: white;
   font-family: 'courier new', monospace;
+  color: #222222;
+  /* app-state data viewer
+     ========================================================================== */
 }
 #--re-frame-trace-- * {
   all: unset;
@@ -274,4 +277,42 @@
 }
 #--re-frame-trace-- .trace-details {
   cursor: pointer;
+}
+#--re-frame-trace-- .re-frame-trace--collection {
+  border-left: 1px solid #efeef1;
+  margin-left: 10px;
+  padding-left: 10px;
+}
+#--re-frame-trace-- .re-frame-trace--primative:not(:first-child) {
+  margin-left: 10px;
+}
+#--re-frame-trace-- .re-frame-trace--boolean {
+  font-style: italic;
+}
+#--re-frame-trace-- .re-frame-trace--string:before {
+  color: #aaaaaa;
+  content: "\"";
+}
+#--re-frame-trace-- .re-frame-trace--string:after {
+  color: #aaaaaa;
+  content: "\"";
+}
+#--re-frame-trace-- .re-frame-trace--nil {
+  text-decoration: line-through;
+  font-style: italic;
+}
+#--re-frame-trace-- .re-frame-trace--keyword {
+  color: #616cdb;
+}
+#--re-frame-trace-- .re-frame-trace--cljs-core-PersistentArrayMap:before,
+#--re-frame-trace-- .re-frame-trace--cljs-core-PersistentTreeMap:before,
+#--re-frame-trace-- .re-frame-trace--cljs-core-PersistentVector:before {
+  color: #aaaaaa;
+  content: "{";
+}
+#--re-frame-trace-- .re-frame-trace--cljs-core-PersistentArrayMap:after,
+#--re-frame-trace-- .re-frame-trace--cljs-core-PersistentTreeMap:after,
+#--re-frame-trace-- .re-frame-trace--cljs-core-PersistentVector:after {
+  color: #aaaaaa;
+  content: "}";
 }

--- a/resources/day8/re_frame/trace/main.less
+++ b/resources/day8/re_frame/trace/main.less
@@ -189,6 +189,7 @@
   }
   th, td {
     display: table-cell;
+    padding: 0 5px;
   }
   tr {
     display: table-row;
@@ -310,7 +311,7 @@
     flex: 1;
   }
   .panel-content-scrollable {
-    margin: 10px 0 0 10px;
+    margin: 0 10px;
     flex: 1 0 auto;
     height: 100%;
     overflow: auto;

--- a/resources/day8/re_frame/trace/main.less
+++ b/resources/day8/re_frame/trace/main.less
@@ -218,6 +218,7 @@
 
   background: white;
   font-family: 'courier new', monospace;
+  color: @text-color;
 
   tbody {
     color: @text-color-muted;
@@ -328,5 +329,55 @@
   .trace-details {
     cursor: pointer;
   }
-}
 
+  /* app-state data viewer
+     ========================================================================== */
+
+  .re-frame-trace--collection {
+    border-left: 1px solid @light-gray;
+    margin-left: 10px;
+    padding-left: 10px;
+    // background: rgba(0, 0, 0, 0.07);
+  }
+  .re-frame-trace--primative:not(:first-child) {
+    margin-left: 10px;
+    // color: @text-color-muted;
+  }
+  .re-frame-trace--number {
+  }
+  .re-frame-trace--boolean {
+    font-style: italic;
+  }
+  .re-frame-trace--string {
+    &:before {
+      color: @text-color-muted;
+      content: "\"";
+    }
+    &:after {
+      color: @text-color-muted;
+      content: "\"";
+    }
+  }
+  .re-frame-trace--nil {
+    text-decoration: line-through;
+    font-style: italic;
+  }
+  .re-frame-trace--keyword {
+    color: @light-purple;
+  }
+  .re-frame-trace--symbol {
+  }
+  .re-frame-trace--cljs-core-PersistentArrayMap,
+  .re-frame-trace--cljs-core-PersistentTreeMap,
+  .re-frame-trace--cljs-core-PersistentVector {
+    &:before {
+      color: @text-color-muted;
+      content: "{";
+    }
+    &:after {
+      color: @text-color-muted;
+      content: "}";
+    }
+  }
+
+}

--- a/resources/day8/re_frame/trace/main.less
+++ b/resources/day8/re_frame/trace/main.less
@@ -1,3 +1,9 @@
+@light-purple: #616cdb;
+@light-blue: lightblue;
+@light-gray: #efeef1;
+@text-color: #222;
+@text-color-muted: #aaa;
+
 #--re-frame-trace-- {
 
   all: initial;
@@ -24,7 +30,7 @@
      ========================================================================== */
 
   a, a:visited {
-    color: #333;
+    color: @text-color;
     border-bottom: 1px #333 dotted;
   }
   a:hover, a:focus {
@@ -214,7 +220,7 @@
   font-family: 'courier new', monospace;
 
   tbody {
-    color: #aaa;
+    color: @text-color-muted;
   }
   tr:hover {
     transition: all 0.1s ease-out;
@@ -258,7 +264,7 @@
   }
   .tab.active {
     background: transparent;
-    border-bottom: 3px solid lightblue;
+    border-bottom: 3px solid @light-blue;
     border-radius: 0;
     padding-bottom: 1px;
   }
@@ -270,7 +276,7 @@
   }
   .filter-items li {
     color: #333;
-    background: #efefef;
+    background: @light-gray;
     display: inline-block;
     font-size: 0.9em;
     margin:  5px;
@@ -278,7 +284,7 @@
   .filter-items {
     li {
       .filter-item-string {
-        color: #616cdb;
+        color: @light-purple;
       }
     }
 
@@ -304,8 +310,8 @@
     appearance: menulist;
   }
   .nav {
-    background: #efeef1;
-    color: #222;
+    background: @light-gray;
+    color: @text-color;
   }
   .panel-content-top {
     flex: 1;

--- a/src/day8/re_frame/trace.cljs
+++ b/src/day8/re_frame/trace.cljs
@@ -305,7 +305,7 @@
         showing?          (r/atom (localstorage/get "show-panel" false))
         dragging?         (r/atom false)
         pin-to-bottom?    (r/atom true)
-        selected-tab      (r/atom :traces)
+        selected-tab      (r/atom (localstorage/get "selected-tab" :traces))
         window-width      js/window.innerWidth
         handle-keys       (fn [e]
                            (let [combo-key?      (or (.-ctrlKey e) (.-metaKey e) (.-altKey e))
@@ -332,6 +332,10 @@
                :update-show-panel
                (fn [_ _ _ new-state]
                  (localstorage/save! "show-panel" new-state)))
+    (add-watch selected-tab
+               :update-selected-tab
+               (fn [_ _ _ new-state]
+                 (localstorage/save! "selected-tab" new-state)))
     (r/create-class
       {:component-will-mount   (fn []
                                  (toggle-traces showing?)

--- a/src/day8/re_frame/trace.cljs
+++ b/src/day8/re_frame/trace.cljs
@@ -372,7 +372,6 @@
                                           :subvis [subvis/render-subvis traces
                                                     [:div.panel-content-scrollable]]
                                           :app-state [app-state/tab @db/app-db])]]]))})))
-(pprint/pprint @db/app-db)
 (defn panel-div []
   (let [id    "--re-frame-trace--"
         panel (.getElementById js/document id)]

--- a/src/day8/re_frame/trace.cljs
+++ b/src/day8/re_frame/trace.cljs
@@ -5,6 +5,7 @@
             [day8.re-frame.trace.components :as components]
             [day8.re-frame.trace.localstorage :as localstorage]
             [re-frame.trace :as trace :include-macros true]
+            [re-frame.db :as db]
             [cljs.pprint :as pprint]
             [clojure.string :as str]
             [reagent.core :as r]
@@ -25,8 +26,6 @@
     (if-not (empty? n)
       n
       "")))
-
-
 
 (def static-fns
   {:render
@@ -206,14 +205,14 @@
 
                 (.toFixed duration 1) " ms"]]
               (when show-row?
-                [:tr {:key (str id "-details")}]))))))
+                [:tr {:key (str id "-details")}
                  [:td.trace-details {:col-span 4
                                      :on-click #(.log js/console tags)}
                    (let [tag-str (with-out-str (pprint/pprint tags))
                          string-size-limit 400]
                         (if (< string-size-limit (count tag-str))
                           (str (subs tag-str 0 string-size-limit) " ...")
-                          tag-str))]
+                          tag-str))]]))))))
 (defn render-trace-panel []
   (let [filter-input               (r/atom "")
         filter-items               (r/atom (localstorage/get "filter-items" []))
@@ -372,8 +371,8 @@
                                           :traces [render-trace-panel]
                                           :subvis [subvis/render-subvis traces
                                                     [:div.panel-content-scrollable]]
-                                          :app-state [app-state/tab @traces])]]]))})))
-
+                                          :app-state [app-state/tab @db/app-db])]]]))})))
+(pprint/pprint @db/app-db)
 (defn panel-div []
   (let [id    "--re-frame-trace--"
         panel (.getElementById js/document id)]

--- a/src/day8/re_frame/trace.cljs
+++ b/src/day8/re_frame/trace.cljs
@@ -1,5 +1,6 @@
 (ns day8.re-frame.trace
   (:require [day8.re-frame.trace.subvis :as subvis]
+            [day8.re-frame.trace.app-state :as app-state]
             [day8.re-frame.trace.styles :as styles]
             [day8.re-frame.trace.components :as components]
             [day8.re-frame.trace.localstorage :as localstorage]
@@ -364,11 +365,14 @@
                                             [:button {:class (str "tab button " (when (= @selected-tab :traces) "active"))
                                                       :on-click #(reset! selected-tab :traces)} "Traces"]
                                             [:button {:class (str "tab button " (when (= @selected-tab :subvis) "active"))
-                                                      :on-click #(reset! selected-tab :subvis)} "SubVis"]]]
+                                                      :on-click #(reset! selected-tab :subvis)} "SubVis"]
+                                            [:button {:class (str "tab button " (when (= @selected-tab :app-state) "active"))
+                                                      :on-click #(reset! selected-tab :app-state)} "app-state"]]]
                                         (case @selected-tab
                                           :traces [render-trace-panel]
                                           :subvis [subvis/render-subvis traces
-                                                    [:div.panel-content-scrollable]])]]]))})))
+                                                    [:div.panel-content-scrollable]]
+                                          :app-state [app-state/tab @traces])]]]))})))
 
 (defn panel-div []
   (let [id    "--re-frame-trace--"

--- a/src/day8/re_frame/trace.cljs
+++ b/src/day8/re_frame/trace.cljs
@@ -164,8 +164,7 @@
 (defn render-traces [showing-traces filter-items filter-input trace-detail-expansions]
   (doall
     (for [{:keys [op-type id operation tags duration] :as trace} showing-traces]
-      (let [padding          {:padding "0px 5px 0px 5px"}
-            row-style        (merge padding {:border-top (case op-type :event "1px solid lightgrey" nil)})
+      (let [row-style        {:border-top (case op-type :event "1px solid lightgrey" nil)}
             show-row?        (get-in @trace-detail-expansions [:overrides id]
                                (:show-all? @trace-detail-expansions))
             op-name          (if (vector? operation)
@@ -206,15 +205,14 @@
 
                 (.toFixed duration 1) " ms"]]
               (when show-row?
-                [:tr {:key (str id "-details")}
-                 [:td.trace-details {:col-span 3
+                [:tr {:key (str id "-details")}]))))))
+                 [:td.trace-details {:col-span 4
                                      :on-click #(.log js/console tags)}
                    (let [tag-str (with-out-str (pprint/pprint tags))
                          string-size-limit 400]
                         (if (< string-size-limit (count tag-str))
                           (str (subs tag-str 0 string-size-limit) " ...")
-                          tag-str))]]))))))
-
+                          tag-str))]
 (defn render-trace-panel []
   (let [filter-input               (r/atom "")
         filter-items               (r/atom (localstorage/get "filter-items" []))

--- a/src/day8/re_frame/trace/app_state.cljs
+++ b/src/day8/re_frame/trace/app_state.cljs
@@ -1,16 +1,34 @@
 (ns day8.re-frame.trace.app-state
   (:require [reagent.core :as r]
-            [clojure.string :as str]))
+            [clojure.string :as str]
 
-(defn classname
+            [cljs.pprint :refer [pprint]]))
+
+
+(defn css-munge
+  [string]
+  (str/replace string #"\.|/" "-"))
+
+(defn namespace-css
+  [classname]
+  (str "re-frame-trace--" classname))
+
+(defn type-string
   [obj]
-  (str/replace (pr-str (type obj)) #"\.|/" "-"))
+  (cond
+    (number? obj)    "number"
+    (boolean? obj)   "boolean"
+    (string? obj)    "string"
+    (nil? obj)       "nil"
+    (keyword? obj)   "keyword"
+    (symbol? obj)    "symbol"
+    :else (pr-str (type obj))))
 
 (defn view
   [data]
-  (if (string? data)
-    [:span.data-string data]
-    [:div {:class (classname data)}]))
+  (if (coll? data)
+    [:div {:class (str (namespace-css "collection") " " (namespace-css (css-munge (type-string data))))}]
+    [:span {:class (namespace-css (css-munge (type-string data)))} (str data)]))
 
 (defn crawl
   [data]
@@ -19,5 +37,8 @@
     (view data)))
 
 (defn tab [data]
-  (println (crawl data))
-  (crawl data))
+  (pprint data)
+  (pprint (crawl data))
+  [:div {:style {:flex "1 0 auto" :width "100%" :height "100%" :display "flex" :flex-direction "column"}}
+    [:div.panel-content-scrollable
+     (crawl data)]])

--- a/src/day8/re_frame/trace/app_state.cljs
+++ b/src/day8/re_frame/trace/app_state.cljs
@@ -27,8 +27,8 @@
 (defn view
   [data]
   (if (coll? data)
-    [:div {:class (str (namespace-css "collection") " " (namespace-css (css-munge (type-string data))))}]
-    [:span {:class (namespace-css (css-munge (type-string data)))} (str data)]))
+    [:div  {:class (str (namespace-css "collection") " " (namespace-css (css-munge (type-string data))))}]
+    [:span {:class (str (namespace-css "primative") " " (namespace-css (css-munge (type-string data))))} (str data)]))
 
 (defn crawl
   [data]
@@ -37,8 +37,6 @@
     (view data)))
 
 (defn tab [data]
-  (pprint data)
-  (pprint (crawl data))
   [:div {:style {:flex "1 0 auto" :width "100%" :height "100%" :display "flex" :flex-direction "column"}}
     [:div.panel-content-scrollable
      (crawl data)]])

--- a/src/day8/re_frame/trace/app_state.cljs
+++ b/src/day8/re_frame/trace/app_state.cljs
@@ -1,0 +1,23 @@
+(ns day8.re-frame.trace.app-state
+  (:require [reagent.core :as r]
+            [clojure.string :as str]))
+
+(defn classname
+  [obj]
+  (str/replace (pr-str (type obj)) #"\.|/" "-"))
+
+(defn view
+  [data]
+  (if (string? data)
+    [:span.data-string data]
+    [:div {:class (classname data)}]))
+
+(defn crawl
+  [data]
+  (if (coll? data)
+    (into (view data) (mapv crawl data))
+    (view data)))
+
+(defn tab [data]
+  (println (crawl data))
+  (crawl data))


### PR DESCRIPTION
Work in progress!

This tab shows the app state. Lots of interesting future features to be added, but I'm putting up a PR for comments and discussion.

Currently it's statically showing the app-state, aka the atom `db/app-db`!

I imagine some of the work here would be useful/reusable for #52.

preview:

```clojure
{:todos
 {1 {:id 1 :title "eat snacks" :done false}
  2 {:id 2 :title "bike to lake" :done false}}
 :showing :all}
```

![WIP app-state tab](https://user-images.githubusercontent.com/1589186/29973268-4e9469ac-8f2f-11e7-81ef-4f6f15db7e14.png)
