### PR TITLE
Bug: traces table clipped at the bottom

### DIFF
--- a/resources/day8/re_frame/trace/main.css
+++ b/resources/day8/re_frame/trace/main.css
@@ -259,11 +259,16 @@
 #--re-frame-trace-- .nav {
   background: #efeef1;
   color: #222222;
+}
 #--re-frame-trace-- .panel-content-scrollable {
   margin: 0 10px;
   flex: 1 1 auto;
   height: 100%;
   overflow: auto;
+  padding-top: 10px;
+  -webkit-box-shadow: inset -1px 18px 13px -22px rgba(0, 0, 0, 0.7);
+  -moz-box-shadow: inset -1px 18px 13px -22px rgba(0, 0, 0, 0.7);
+  box-shadow: inset -1px 18px 13px -22px rgba(0, 0, 0, 0.7);
 }
 #--re-frame-trace-- .tab-contents {
   display: flex;

--- a/resources/day8/re_frame/trace/main.css
+++ b/resources/day8/re_frame/trace/main.css
@@ -259,15 +259,16 @@
 #--re-frame-trace-- .nav {
   background: #efeef1;
   color: #222222;
-}
-#--re-frame-trace-- .panel-content-top {
-  flex: 1;
-}
 #--re-frame-trace-- .panel-content-scrollable {
   margin: 0 10px;
-  flex: 1 0 auto;
+  flex: 1 1 auto;
   height: 100%;
   overflow: auto;
+}
+#--re-frame-trace-- .tab-contents {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
 }
 #--re-frame-trace-- .filter-control {
   margin: 10px 0 0 10px;

--- a/resources/day8/re_frame/trace/main.less
+++ b/resources/day8/re_frame/trace/main.less
@@ -320,6 +320,10 @@
     flex: 1 1 auto;
     height: 100%;
     overflow: auto;
+    padding-top: 10px;
+    -webkit-box-shadow: inset -1px 18px 13px -22px rgba(0,0,0,0.7);
+    -moz-box-shadow: inset -1px 18px 13px -22px rgba(0,0,0,0.7);
+    box-shadow: inset -1px 18px 13px -22px rgba(0,0,0,0.7);
   }
   .tab-contents {
     display: flex;
@@ -333,4 +337,3 @@
     cursor: pointer;
   }
 }
-

--- a/resources/day8/re_frame/trace/main.less
+++ b/resources/day8/re_frame/trace/main.less
@@ -314,13 +314,17 @@
     color: @text-color;
   }
   .panel-content-top {
-    flex: 1;
   }
   .panel-content-scrollable {
     margin: 0 10px;
-    flex: 1 0 auto;
+    flex: 1 1 auto;
     height: 100%;
     overflow: auto;
+  }
+  .tab-contents {
+    display: flex;
+    flex: 1 1 auto;
+    flex-direction: column;
   }
   .filter-control {
     margin: 10px 0 0 10px;

--- a/src/day8/re_frame/trace.cljs
+++ b/src/day8/re_frame/trace.cljs
@@ -236,7 +236,7 @@
                                        (add-filter filter-items @filter-input @filter-type))))]
 
 
-        [:div {:style {:flex "1 0 auto" :width "100%" :height "100%" :display "flex" :flex-direction "column"}}
+        [:div.tab-contents
           [:div.filter-control
            [:div.filter-control-input
             [:select {:value @filter-type


### PR DESCRIPTION
Previously, the last couple traces would be past the scrollable portion of the traces table. This PR fixes that, now you can see all the traces!

(to see CSS changes, you currently have to save the `styles.cljs` file to trigger figwheel to reinject the new CSS)

**before**: 
(note how there are three traces past where you can scroll, and the bottom of the scrollbar is cut off too)
![bug: can't see the last three traces](https://user-images.githubusercontent.com/1589186/30062536-d00e57f8-924b-11e7-9f8e-fcad37ca5901.png)

**after**:
![bug fix the entire traces table is now showing](https://user-images.githubusercontent.com/1589186/30062239-c0e3becc-924a-11e7-89bb-9426f145d497.png)
