### PR TITLE
Table readability

### DIFF
--- a/resources/day8/re_frame/trace/main.css
+++ b/resources/day8/re_frame/trace/main.css
@@ -181,9 +181,12 @@
 #--re-frame-trace-- thead {
   font-weight: bold;
 }
-#--re-frame-trace-- th,
-#--re-frame-trace-- td {
-  padding: 10px 5px;
+#--re-frame-trace-- tr th,
+#--re-frame-trace-- tr td {
+  padding: 10px 0;
+}
+#--re-frame-trace-- tr th:first-child {
+  text-align: right;
 }
 #--re-frame-trace-- tr:hover {
   background: #f7f7f8;
@@ -218,6 +221,7 @@
 }
 #--re-frame-trace-- tr td.trace--op-string {
   word-break: break-all;
+  width: 100%;
 }
 #--re-frame-trace-- tr td.trace--details-tags {
   padding: 0;
@@ -242,6 +246,14 @@
 #--re-frame-trace-- tr td .op-string:hover {
   border-bottom: 1px dotted #616cdb;
   padding-bottom: 0;
+}
+#--re-frame-trace-- tr th:first-child,
+#--re-frame-trace-- tr td:first-child {
+  padding-left: 7px;
+}
+#--re-frame-trace-- tr th:last-child,
+#--re-frame-trace-- tr td:last-child {
+  padding-right: 7px;
 }
 #--re-frame-trace-- .button {
   padding: 5px 5px 3px;
@@ -320,7 +332,6 @@
   color: #222222;
 }
 #--re-frame-trace-- .panel-content-scrollable {
-  margin: 0 10px;
   flex: 1 1 auto;
   height: 100%;
   overflow: auto;

--- a/resources/day8/re_frame/trace/main.css
+++ b/resources/day8/re_frame/trace/main.css
@@ -83,6 +83,10 @@
 #--re-frame-trace-- input {
   overflow: visible;
 }
+#--re-frame-trace-- button:focus,
+#--re-frame-trace-- select:focus {
+  outline: #999999 dotted 1px;
+}
 #--re-frame-trace-- button,
 #--re-frame-trace-- html [type="button"],
 #--re-frame-trace-- [type="reset"],
@@ -210,13 +214,19 @@
 #--re-frame-trace-- tr.trace--details {
   color: #8f8f8f;
 }
-#--re-frame-trace-- tr.trace--details:hover {
+#--re-frame-trace-- tr.trace--details:hover,
+#--re-frame-trace-- tr.trace--details:focus {
   color: #5c5c5c;
 }
-#--re-frame-trace-- tr.trace--details:hover .trace--details-icon:before {
+#--re-frame-trace-- tr.trace--details:hover .trace--details-icon:before,
+#--re-frame-trace-- tr.trace--details:focus .trace--details-icon:before {
   color: #222222;
   cursor: pointer;
   content: "🖶";
+}
+#--re-frame-trace-- tr.trace--details:focus .trace--details-tags-text {
+  border-left: 1px dotted #999999;
+  padding-left: 7px;
 }
 #--re-frame-trace-- tr td.trace--toggle {
   color: #a8a8a8;
@@ -225,6 +235,7 @@
 }
 #--re-frame-trace-- tr td.trace--toggle button:focus {
   color: #222222;
+  outline: none;
 }
 #--re-frame-trace-- tr td.trace--op {
   color: #8f8f8f;
@@ -278,12 +289,8 @@
   border-bottom: 1px dotted #888;
   font-weight: normal;
 }
-#--re-frame-trace-- .button:focus,
 #--re-frame-trace-- .text-button:focus {
-  border-radius: 2px 2px 0 0;
-  -webkit-box-shadow: inset 0px -5px 0px 0px rgba(0, 0, 0, 0.3);
-  -moz-box-shadow: inset 0px -5px 0px 0px rgba(0, 0, 0, 0.3);
-  box-shadow: inset 0px -5px 0px 0px rgba(0, 0, 0, 0.3);
+  outline: #999999 dotted 1px;
 }
 #--re-frame-trace-- .icon-button {
   font-size: 10px;
@@ -306,18 +313,16 @@
 }
 #--re-frame-trace-- ul.filter-items {
   list-style-type: none;
-  padding: 0;
-  margin: 0 -5px;
-  margin-top: 10px;
+  margin: 0 5px;
 }
-#--re-frame-trace-- .filter-items li {
+#--re-frame-trace-- ul.filter-items li {
   color: #333;
   background: #efeef1;
   display: inline-block;
   font-size: 0.9em;
-  margin: 5px;
+  margin: 10px 5px;
 }
-#--re-frame-trace-- .filter-items li .filter-item-string {
+#--re-frame-trace-- ul.filter-items li .filter-item-string {
   color: #616cdb;
 }
 #--re-frame-trace-- .icon {
@@ -331,14 +336,34 @@
 #--re-frame-trace-- .icon-remove {
   margin-left: 10px;
 }
-#--re-frame-trace-- select {
+#--re-frame-trace-- .filter {
+  box-shadow: -7px 15px 6px -15px rgba(0, 0, 0, 0.3);
+  z-index: 1001;
+}
+#--re-frame-trace-- .filter .filter-control select {
+  border: none;
+  border-bottom: 1px solid #8f8f8f;
   background: white;
+  display: inline-block;
   font-family: 'courier new', monospace;
   font-size: 1em;
   padding: 2px 0 0 0;
   -moz-appearance: menulist;
   -webkit-appearance: menulist;
   appearance: menulist;
+}
+#--re-frame-trace-- .filter .filter-control .filter-control-input {
+  border-bottom: 1px solid #8f8f8f;
+  display: inline-block;
+}
+#--re-frame-trace-- .filter .filter-control .filter-control-input:before {
+  display: inline-block;
+  color: #8f8f8f;
+  content: "⚲";
+  transform: rotate(-45deg);
+}
+#--re-frame-trace-- .filter .filter-control .filter-control-input input {
+  border: none;
 }
 #--re-frame-trace-- .nav {
   background: #efeef1;
@@ -349,9 +374,7 @@
   height: 100%;
   overflow: auto;
   padding-top: 10px;
-  -webkit-box-shadow: inset -1px 18px 13px -22px rgba(0, 0, 0, 0.7);
-  -moz-box-shadow: inset -1px 18px 13px -22px rgba(0, 0, 0, 0.7);
-  box-shadow: inset -1px 18px 13px -22px rgba(0, 0, 0, 0.7);
+  z-index: 1000;
 }
 #--re-frame-trace-- .tab-contents {
   display: flex;

--- a/resources/day8/re_frame/trace/main.css
+++ b/resources/day8/re_frame/trace/main.css
@@ -244,7 +244,6 @@
 }
 #--re-frame-trace-- tr td.trace--op-string {
   word-break: break-all;
-  width: 100%;
 }
 #--re-frame-trace-- tr td.trace--details-tags {
   padding: 0;

--- a/resources/day8/re_frame/trace/main.css
+++ b/resources/day8/re_frame/trace/main.css
@@ -389,6 +389,9 @@
 #--re-frame-trace-- .filter-control {
   margin: 10px 0 0 10px;
 }
-#--re-frame-trace-- .highlight {
+#--re-frame-trace-- .filter-items-count.active {
   background: #ffff00;
+}
+#--re-frame-trace-- .filter-items-count.active:hover {
+  text-decoration: line-through;
 }

--- a/resources/day8/re_frame/trace/main.css
+++ b/resources/day8/re_frame/trace/main.css
@@ -77,7 +77,7 @@
   font-family: "courier new", monospace;
   font-size: 100%;
   padding: 3px 3px 1px 3px;
-  border: 1px solid black;
+  border: 1px solid #999999;
 }
 #--re-frame-trace-- button,
 #--re-frame-trace-- input {
@@ -155,13 +155,8 @@
   -webkit-border-horizontal-spacing: 0;
   -webkit-border-vertical-spacing: 0;
 }
-#--re-frame-trace-- th,
-#--re-frame-trace-- td {
-  display: table-cell;
-  padding: 0 5px;
-}
-#--re-frame-trace-- tr {
-  display: table-row;
+#--re-frame-trace-- table {
+  display: table;
 }
 #--re-frame-trace-- thead {
   display: table-header-group;
@@ -169,20 +164,77 @@
 #--re-frame-trace-- tbody {
   display: table-row-group;
 }
+#--re-frame-trace-- th,
+#--re-frame-trace-- td {
+  display: table-cell;
+}
+#--re-frame-trace-- tr {
+  display: table-row;
+}
 #--re-frame-trace-- table {
-  display: table;
   width: 100%;
+  font-size: 14px;
 }
 #--re-frame-trace-- tbody {
-  color: #aaaaaa;
+  color: #222222;
+}
+#--re-frame-trace-- thead {
+  font-weight: bold;
+}
+#--re-frame-trace-- th,
+#--re-frame-trace-- td {
+  padding: 8px 5px;
 }
 #--re-frame-trace-- tr:hover {
-  transition: all 0.1s ease-out;
-  background: aliceblue;
-  filter: brightness(90%);
+  background: #f7f7f8;
 }
-#--re-frame-trace-- tr:nth-child(even) {
-  background: aliceblue;
+#--re-frame-trace-- tr.trace--trace {
+  border-top: 1px solid #ececec;
+}
+#--re-frame-trace-- tr.trace--sub-create .trace--op {
+  color: #119457;
+}
+#--re-frame-trace-- tr.trace--sub-run .trace--op {
+  color: #762cff;
+}
+#--re-frame-trace-- tr.trace--event .trace--op {
+  color: #ab8c00;
+}
+#--re-frame-trace-- tr.trace--render .trace--op {
+  color: #0091e2;
+}
+#--re-frame-trace-- tr.trace--fsm-trigger .trace--op {
+  color: #284694;
+}
+#--re-frame-trace-- tr td.trace--toggle {
+  color: #8f8f8f;
+  padding: 0;
+  text-align: right;
+}
+#--re-frame-trace-- tr td.trace--op {
+  color: #8f8f8f;
+  padding-left: 0;
+  white-space: nowrap;
+}
+#--re-frame-trace-- tr td.trace--op-string {
+  word-break: break-all;
+}
+#--re-frame-trace-- tr td.trace--details-tags {
+  color: #8f8f8f;
+  cursor: pointer;
+}
+#--re-frame-trace-- tr td.trace--meta {
+  color: #8f8f8f;
+  white-space: nowrap;
+  text-align: right;
+}
+#--re-frame-trace-- tr td .op-string {
+  cursor: pointer;
+  padding: 1px;
+}
+#--re-frame-trace-- tr td .op-string:hover {
+  border-bottom: 1px dotted #616cdb;
+  padding-bottom: 0;
 }
 #--re-frame-trace-- .button {
   padding: 5px 5px 3px;
@@ -216,7 +268,7 @@
 }
 #--re-frame-trace-- .tab.active {
   background: transparent;
-  border-bottom: 3px solid #add8e6;
+  border-bottom: 3px solid #808080;
   border-radius: 0;
   padding-bottom: 1px;
 }
@@ -277,7 +329,4 @@
 }
 #--re-frame-trace-- .filter-control {
   margin: 10px 0 0 10px;
-}
-#--re-frame-trace-- .trace-details {
-  cursor: pointer;
 }

--- a/resources/day8/re_frame/trace/main.css
+++ b/resources/day8/re_frame/trace/main.css
@@ -183,7 +183,7 @@
 }
 #--re-frame-trace-- th,
 #--re-frame-trace-- td {
-  padding: 8px 5px;
+  padding: 10px 5px;
 }
 #--re-frame-trace-- tr:hover {
   background: #f7f7f8;
@@ -192,16 +192,16 @@
   border-top: 1px solid #ececec;
 }
 #--re-frame-trace-- tr.trace--sub-create .trace--op {
-  color: #119457;
+  color: #008766;
 }
 #--re-frame-trace-- tr.trace--sub-run .trace--op {
   color: #762cff;
 }
 #--re-frame-trace-- tr.trace--event .trace--op {
-  color: #ab8c00;
+  color: #a66900;
 }
 #--re-frame-trace-- tr.trace--render .trace--op {
-  color: #0091e2;
+  color: #007cc2;
 }
 #--re-frame-trace-- tr.trace--fsm-trigger .trace--op {
   color: #284694;
@@ -220,8 +220,15 @@
   word-break: break-all;
 }
 #--re-frame-trace-- tr td.trace--details-tags {
+  padding: 0;
   color: #8f8f8f;
   cursor: pointer;
+}
+#--re-frame-trace-- tr td.trace--details-tags .trace--details-tags-text {
+  border-left: 3px solid #efeef1;
+  padding: 8px 5px;
+  padding-left: 8px;
+  margin-bottom: 5px;
 }
 #--re-frame-trace-- tr td.trace--meta {
   color: #8f8f8f;

--- a/resources/day8/re_frame/trace/main.css
+++ b/resources/day8/re_frame/trace/main.css
@@ -183,16 +183,14 @@
 }
 #--re-frame-trace-- tr th,
 #--re-frame-trace-- tr td {
-  padding: 10px 0;
+  padding: 6px;
 }
 #--re-frame-trace-- tr th:first-child {
   text-align: right;
 }
-#--re-frame-trace-- tr:hover {
-  background: #f7f7f8;
-}
-#--re-frame-trace-- tr.trace--trace {
-  border-top: 1px solid #ececec;
+#--re-frame-trace-- tr.trace--trace-even,
+#--re-frame-trace-- tr.trace--trace-even + .trace--details {
+  background: #fafafa;
 }
 #--re-frame-trace-- tr.trace--sub-create .trace--op {
   color: #008766;
@@ -210,7 +208,7 @@
   color: #284694;
 }
 #--re-frame-trace-- tr td.trace--toggle {
-  color: #8f8f8f;
+  color: #a8a8a8;
   padding: 0;
   text-align: right;
 }
@@ -229,7 +227,6 @@
   cursor: pointer;
 }
 #--re-frame-trace-- tr td.trace--details-tags .trace--details-tags-text {
-  border-left: 3px solid #efeef1;
   padding: 8px 5px;
   padding-left: 8px;
   margin-bottom: 5px;
@@ -246,6 +243,9 @@
 #--re-frame-trace-- tr td .op-string:hover {
   border-bottom: 1px dotted #616cdb;
   padding-bottom: 0;
+}
+#--re-frame-trace-- tr:hover .trace--toggle {
+  color: #222222;
 }
 #--re-frame-trace-- tr th:first-child,
 #--re-frame-trace-- tr td:first-child {

--- a/resources/day8/re_frame/trace/main.css
+++ b/resources/day8/re_frame/trace/main.css
@@ -315,15 +315,20 @@
   list-style-type: none;
   margin: 0 5px;
 }
-#--re-frame-trace-- ul.filter-items li {
-  color: #333;
-  background: #efeef1;
+#--re-frame-trace-- ul.filter-items .filter-item {
+  color: #8f8f8f;
+  background: #fafafa;
+  border: 1px solid #efeef1;
   display: inline-block;
   font-size: 0.9em;
   margin: 10px 5px;
 }
-#--re-frame-trace-- ul.filter-items li .filter-item-string {
-  color: #616cdb;
+#--re-frame-trace-- ul.filter-items .filter-item .filter-item-string {
+  color: #222222;
+  background: #ffff00;
+}
+#--re-frame-trace-- ul.filter-items .filter-item:hover {
+  text-decoration: line-through;
 }
 #--re-frame-trace-- .icon {
   display: inline-block;
@@ -383,4 +388,7 @@
 }
 #--re-frame-trace-- .filter-control {
   margin: 10px 0 0 10px;
+}
+#--re-frame-trace-- .highlight {
+  background: #ffff00;
 }

--- a/resources/day8/re_frame/trace/main.css
+++ b/resources/day8/re_frame/trace/main.css
@@ -212,6 +212,9 @@
   padding: 0;
   text-align: right;
 }
+#--re-frame-trace-- tr td.trace--toggle button:focus {
+  color: #222222;
+}
 #--re-frame-trace-- tr td.trace--op {
   color: #8f8f8f;
   padding-left: 0;

--- a/resources/day8/re_frame/trace/main.css
+++ b/resources/day8/re_frame/trace/main.css
@@ -207,6 +207,17 @@
 #--re-frame-trace-- tr.trace--fsm-trigger .trace--op {
   color: #284694;
 }
+#--re-frame-trace-- tr.trace--details {
+  color: #8f8f8f;
+}
+#--re-frame-trace-- tr.trace--details:hover {
+  color: #5c5c5c;
+}
+#--re-frame-trace-- tr.trace--details:hover .trace--details-icon:before {
+  color: #222222;
+  cursor: pointer;
+  content: "🖶";
+}
 #--re-frame-trace-- tr td.trace--toggle {
   color: #a8a8a8;
   padding: 0;
@@ -226,7 +237,6 @@
 }
 #--re-frame-trace-- tr td.trace--details-tags {
   padding: 0;
-  color: #8f8f8f;
   cursor: pointer;
 }
 #--re-frame-trace-- tr td.trace--details-tags .trace--details-tags-text {

--- a/resources/day8/re_frame/trace/main.less
+++ b/resources/day8/re_frame/trace/main.less
@@ -281,6 +281,17 @@
       }
     }
     &.trace--details {
+      color: @text-color-muted;
+
+      &:hover {
+        color: darken(@text-color-muted, 20);
+
+        .trace--details-icon:before {
+          color: @text-color;
+          cursor: pointer;
+          content: "🖶";
+        }
+      }
     }
 
     td {
@@ -304,7 +315,6 @@
       }
       &.trace--details-tags {
         padding: 0;
-        color: @text-color-muted;
         cursor: pointer;
 
         .trace--details-tags-text {

--- a/resources/day8/re_frame/trace/main.less
+++ b/resources/day8/re_frame/trace/main.less
@@ -494,7 +494,14 @@
   .filter-control {
     margin: 10px 0 0 10px;
   }
-  .highlight {
-    background: @yellow;
+
+  .filter-items-count {
+    &.active {
+      background: @yellow;
+
+      &:hover {
+        text-decoration: line-through;
+      }
+    }
   }
 }

--- a/resources/day8/re_frame/trace/main.less
+++ b/resources/day8/re_frame/trace/main.less
@@ -1,11 +1,11 @@
 @background-blue: #e7f1ff;
 @background-gray: #f7f7f8;
-@dark-green: #119457;
-@dark-gold: #ab8c00;
+@dark-green: #008766;
+@dark-gold: #A66900;
 @dark-purple: #762cff;
 @dark-blue: #284694;
 @dark-gray: gray;
-@dark-skyblue: #0091e2;
+@dark-skyblue: #007CC2;
 @medium-gray: #999;
 @light-purple: #616cdb;
 @light-blue: lightblue;
@@ -237,7 +237,7 @@
     font-weight: bold;
   }
   th, td {
-    padding: 8px 5px;
+    padding: 10px 5px;
   }
   tr {
     &:hover {
@@ -291,8 +291,16 @@
         word-break: break-all;
       }
       &.trace--details-tags {
+        padding: 0;
         color: @text-color-muted;
         cursor: pointer;
+
+        .trace--details-tags-text {
+          border-left: 3px solid @light-gray;
+          padding: 8px 5px;
+          padding-left: 8px;
+          margin-bottom: 5px;
+        }
       }
       &.trace--meta {
         color: @text-color-muted;

--- a/resources/day8/re_frame/trace/main.less
+++ b/resources/day8/re_frame/trace/main.less
@@ -288,6 +288,10 @@
         color: @background-gray;
         padding: 0;
         text-align: right;
+
+        button:focus {
+          color: @text-color;
+        }
       }
       &.trace--op {
         color: @text-color-muted;

--- a/resources/day8/re_frame/trace/main.less
+++ b/resources/day8/re_frame/trace/main.less
@@ -11,6 +11,7 @@
 @light-purple: #616cdb;
 @light-blue: lightblue;
 @light-gray: #efeef1;
+@yellow: yellow;
 @text-color: #222;
 @text-color-muted: #8f8f8f;
 
@@ -409,15 +410,21 @@
     list-style-type: none;
     margin: 0 5px;
 
-    li {
-      color: #333;
-      background: @light-gray;
+    .filter-item {
+      color: @text-color-muted;
+      background: @background-gray-hint;
+      border: 1px solid @light-gray;
       display: inline-block;
       font-size: 0.9em;
       margin: 10px 5px;
 
       .filter-item-string {
-        color: @light-purple;
+        color: @text-color;
+        background: @yellow;
+      }
+
+      &:hover {
+        text-decoration: line-through;
       }
     }
   }
@@ -486,5 +493,8 @@
   }
   .filter-control {
     margin: 10px 0 0 10px;
+  }
+  .highlight {
+    background: @yellow;
   }
 }

--- a/resources/day8/re_frame/trace/main.less
+++ b/resources/day8/re_frame/trace/main.less
@@ -236,10 +236,16 @@
   thead {
     font-weight: bold;
   }
-  th, td {
-    padding: 10px 5px;
-  }
+
   tr {
+    th, td {
+      padding: 10px 0;
+    }
+
+    th:first-child {
+      text-align: right;
+    }
+
     &:hover {
       background: @background-gray;
     }
@@ -289,6 +295,7 @@
       }
       &.trace--op-string {
         word-break: break-all;
+        width: 100%;
       }
       &.trace--details-tags {
         padding: 0;
@@ -317,9 +324,15 @@
         }
       }
     }
-  }
-  tr:nth-child(even) {
-    // background: @background-gray;
+
+    th, td {
+      &:first-child {
+        padding-left: 7px;
+      }
+      &:last-child {
+        padding-right: 7px;
+      }
+    }
   }
   .button {
     padding: 5px 5px 3px;
@@ -407,7 +420,7 @@
   .panel-content-top {
   }
   .panel-content-scrollable {
-    margin: 0 10px;
+    padding-top: 10px;
     flex: 1 1 auto;
     height: 100%;
     overflow: auto;

--- a/resources/day8/re_frame/trace/main.less
+++ b/resources/day8/re_frame/trace/main.less
@@ -105,6 +105,13 @@
     overflow: visible;
   }
 
+  button,
+  select {
+    &:focus {
+      outline: @medium-gray dotted 1px;
+    }
+  }
+
   /**
    * 1. Prevent a WebKit bug where (2) destroys native `audio` and `video`
    *    controls in Android 4.
@@ -283,13 +290,21 @@
     &.trace--details {
       color: @text-color-muted;
 
-      &:hover {
+      &:hover,
+      &:focus {
         color: darken(@text-color-muted, 20);
 
         .trace--details-icon:before {
           color: @text-color;
           cursor: pointer;
           content: "🖶";
+        }
+      }
+
+      &:focus {
+        .trace--details-tags-text {
+          border-left: 1px dotted @medium-gray;
+          padding-left: 7px;
         }
       }
     }
@@ -302,6 +317,7 @@
 
         button:focus {
           color: @text-color;
+          outline: none;
         }
       }
       &.trace--op {
@@ -363,12 +379,9 @@
   .text-button {
     border-bottom: 1px dotted #888;
     font-weight: normal;
-  }
-  .button:focus, .text-button:focus {
-    border-radius: 2px 2px 0 0;
-    -webkit-box-shadow: inset 0px -5px 0px 0px rgba(0,0,0,0.3);
-    -moz-box-shadow: inset 0px -5px 0px 0px rgba(0,0,0,0.3);
-    box-shadow: inset 0px -5px 0px 0px rgba(0,0,0,0.3);
+    &:focus {
+      outline: @medium-gray dotted 1px;
+    }
   }
   .icon-button {
     font-size: 10px;
@@ -394,24 +407,19 @@
   }
   ul.filter-items {
     list-style-type: none;
-    padding: 0;
-    margin: 0 -5px;
-    margin-top: 10px;
-  }
-  .filter-items li {
-    color: #333;
-    background: @light-gray;
-    display: inline-block;
-    font-size: 0.9em;
-    margin:  5px;
-  }
-  .filter-items {
+    margin: 0 5px;
+
     li {
+      color: #333;
+      background: @light-gray;
+      display: inline-block;
+      font-size: 0.9em;
+      margin: 10px 5px;
+
       .filter-item-string {
         color: @light-purple;
       }
     }
-
   }
   .icon {
     display: inline-block;
@@ -424,14 +432,38 @@
   .icon-remove {
     margin-left: 10px;
   }
-  select {
-    background: white;
-    font-family: 'courier new', monospace;
-    font-size: 1em;
-    padding: 2px 0 0 0;
-    -moz-appearance: menulist;
-    -webkit-appearance: menulist;
-    appearance: menulist;
+  .filter {
+    box-shadow: -7px 15px 6px -15px rgba(0, 0, 0, 0.3);
+    z-index: 1001;
+
+    .filter-control {
+      select {
+        border: none;
+        border-bottom: 1px solid @text-color-muted;
+        background: white;
+        display: inline-block;
+        font-family: 'courier new', monospace;
+        font-size: 1em;
+        padding: 2px 0 0 0;
+        -moz-appearance: menulist;
+        -webkit-appearance: menulist;
+        appearance: menulist;
+      }
+      .filter-control-input {
+        border-bottom: 1px solid @text-color-muted;
+        display: inline-block;
+
+        &:before {
+          display: inline-block;
+          color: @text-color-muted;
+          content: "⚲";
+          transform: rotate(-45deg);
+        }
+        input {
+          border: none;
+        }
+      }
+    }
   }
   .nav {
     background: @light-gray;
@@ -445,9 +477,7 @@
     height: 100%;
     overflow: auto;
     padding-top: 10px;
-    -webkit-box-shadow: inset -1px 18px 13px -22px rgba(0,0,0,0.7);
-    -moz-box-shadow: inset -1px 18px 13px -22px rgba(0,0,0,0.7);
-    box-shadow: inset -1px 18px 13px -22px rgba(0,0,0,0.7);
+    z-index: 1000;
   }
   .tab-contents {
     display: flex;

--- a/resources/day8/re_frame/trace/main.less
+++ b/resources/day8/re_frame/trace/main.less
@@ -328,7 +328,6 @@
       }
       &.trace--op-string {
         word-break: break-all;
-        width: 100%;
       }
       &.trace--details-tags {
         padding: 0;

--- a/resources/day8/re_frame/trace/main.less
+++ b/resources/day8/re_frame/trace/main.less
@@ -1,5 +1,6 @@
 @background-blue: #e7f1ff;
-@background-gray: #f7f7f8;
+@background-gray: #a8a8a8;
+@background-gray-hint: #fafafa;
 @dark-green: #008766;
 @dark-gold: #A66900;
 @dark-purple: #762cff;
@@ -239,19 +240,19 @@
 
   tr {
     th, td {
-      padding: 10px 0;
+      padding: 6px;
     }
 
     th:first-child {
       text-align: right;
     }
 
-    &:hover {
-      background: @background-gray;
+    &.trace--trace {
     }
 
-    &.trace--trace {
-      border-top: 1px solid #ececec;
+    &.trace--trace-even,
+    &.trace--trace-even + .trace--details {
+      background: @background-gray-hint;
     }
 
     &.trace--sub-create {
@@ -284,7 +285,7 @@
 
     td {
       &.trace--toggle {
-        color: @text-color-muted;
+        color: @background-gray;
         padding: 0;
         text-align: right;
       }
@@ -303,7 +304,6 @@
         cursor: pointer;
 
         .trace--details-tags-text {
-          border-left: 3px solid @light-gray;
           padding: 8px 5px;
           padding-left: 8px;
           margin-bottom: 5px;
@@ -322,6 +322,12 @@
           border-bottom: 1px dotted @light-purple;
           padding-bottom: 0;
         }
+      }
+    }
+
+    &:hover {
+      .trace--toggle {
+        color: @text-color;
       }
     }
 

--- a/resources/day8/re_frame/trace/main.less
+++ b/resources/day8/re_frame/trace/main.less
@@ -1,8 +1,17 @@
+@background-blue: #e7f1ff;
+@background-gray: #f7f7f8;
+@dark-green: #119457;
+@dark-gold: #ab8c00;
+@dark-purple: #762cff;
+@dark-blue: #284694;
+@dark-gray: gray;
+@dark-skyblue: #0091e2;
+@medium-gray: #999;
 @light-purple: #616cdb;
 @light-blue: lightblue;
 @light-gray: #efeef1;
 @text-color: #222;
-@text-color-muted: #aaa;
+@text-color-muted: #8f8f8f;
 
 #--re-frame-trace-- {
 
@@ -87,7 +96,7 @@
     font-size: 100%;
     // line-height: 1.15;
     padding: 3px 3px 1px 3px;
-    border: 1px solid black;
+    border: 1px solid @medium-gray;
   }
 
   button, // Show the overflow in IE.
@@ -193,12 +202,8 @@
     -webkit-border-horizontal-spacing: 0;
     -webkit-border-vertical-spacing: 0;
   }
-  th, td {
-    display: table-cell;
-    padding: 0 5px;
-  }
-  tr {
-    display: table-row;
+  table {
+    display: table;
   }
   thead {
     display: table-header-group;
@@ -206,9 +211,11 @@
   tbody {
     display: table-row-group;
   }
-  table {
-    display: table;
-    width: 100%;
+  th, td {
+    display: table-cell;
+  }
+  tr {
+    display: table-row;
   }
 
 
@@ -219,16 +226,92 @@
   background: white;
   font-family: 'courier new', monospace;
 
-  tbody {
-    color: @text-color-muted;
+  table {
+    width: 100%;
+    font-size: 14px;
   }
-  tr:hover {
-    transition: all 0.1s ease-out;
-    background: aliceblue;
-    filter: brightness(90%);
+  tbody {
+    color: @text-color;
+  }
+  thead {
+    font-weight: bold;
+  }
+  th, td {
+    padding: 8px 5px;
+  }
+  tr {
+    &:hover {
+      background: @background-gray;
+    }
+
+    &.trace--trace {
+      border-top: 1px solid #ececec;
+    }
+
+    &.trace--sub-create {
+      .trace--op{
+        color: @dark-green;
+      }
+    }
+    &.trace--sub-run {
+      .trace--op{
+        color: @dark-purple;
+      }
+    }
+    &.trace--event {
+      .trace--op{
+        color: @dark-gold;
+      }
+    }
+    &.trace--render {
+      .trace--op{
+        color: @dark-skyblue;
+      }
+    }
+    &.trace--fsm-trigger {
+      .trace--op{
+        color: @dark-blue;
+      }
+    }
+    &.trace--details {
+    }
+
+    td {
+      &.trace--toggle {
+        color: @text-color-muted;
+        padding: 0;
+        text-align: right;
+      }
+      &.trace--op {
+        color: @text-color-muted;
+        padding-left: 0;
+        white-space: nowrap;
+      }
+      &.trace--op-string {
+        word-break: break-all;
+      }
+      &.trace--details-tags {
+        color: @text-color-muted;
+        cursor: pointer;
+      }
+      &.trace--meta {
+        color: @text-color-muted;
+        white-space: nowrap;
+        text-align: right;
+      }
+      .op-string {
+        cursor: pointer;
+        padding: 1px;
+
+        &:hover {
+          border-bottom: 1px dotted @light-purple;
+          padding-bottom: 0;
+        }
+      }
+    }
   }
   tr:nth-child(even) {
-    background: aliceblue;
+    // background: @background-gray;
   }
   .button {
     padding: 5px 5px 3px;
@@ -264,7 +347,7 @@
   }
   .tab.active {
     background: transparent;
-    border-bottom: 3px solid @light-blue;
+    border-bottom: 3px solid @dark-gray;
     border-radius: 0;
     padding-bottom: 1px;
   }
@@ -332,8 +415,5 @@
   }
   .filter-control {
     margin: 10px 0 0 10px;
-  }
-  .trace-details {
-    cursor: pointer;
   }
 }

--- a/src/day8/re_frame/trace.cljs
+++ b/src/day8/re_frame/trace.cljs
@@ -201,11 +201,12 @@
                  [:td]
                  [:td.trace--details-tags {:col-span 4
                                            :on-click #(.log js/console tags)}
-                   (let [tag-str (with-out-str (pprint/pprint tags))
-                         string-size-limit 400]
-                        (if (< string-size-limit (count tag-str))
-                          (str (subs tag-str 0 string-size-limit) " ...")
-                          tag-str))]]))))))
+                   [:div.trace--details-tags-text
+                     (let [tag-str (with-out-str (pprint/pprint tags))
+                           string-size-limit 400]
+                          (if (< string-size-limit (count tag-str))
+                            (str (subs tag-str 0 string-size-limit) " ...")
+                            tag-str))]]]))))))
 (defn render-trace-panel []
   (let [filter-input               (r/atom "")
         filter-items               (r/atom (localstorage/get "filter-items" []))

--- a/src/day8/re_frame/trace.cljs
+++ b/src/day8/re_frame/trace.cljs
@@ -126,8 +126,7 @@
                 (when (pos? (count v))
                   (on-save v)))]
     (fn []
-      [:input {:style       {:margin-left 7}
-               :type        "text"
+      [:input {:type        "text"
                :value       @val
                :auto-focus  true
                :on-change   #(do (reset! val (-> % .-target .-value))
@@ -203,7 +202,8 @@
                              [:td.trace--meta
                               (.toFixed duration 1) " ms"]]
                             (when show-row?
-                              [:tr.trace--details {:key (str id "-details")}
+                              [:tr.trace--details {:key (str id "-details")
+                                                   :tab-index 0}
                                [:td]
                                [:td.trace--details-tags {:col-span 2
                                                          :on-click #(.log js/console tags)}
@@ -239,30 +239,31 @@
 
 
         [:div.tab-contents
-          [:div.filter-control
-           [:div.filter-control-input
-            [:select {:value @filter-type
-                      :on-change #(reset! filter-type (keyword (.. % -target -value)))}
-             [:option {:value "contains"} "contains"]
-             [:option {:value "slower-than"} "slower than"]]
-            [search-input {:on-save save-query
-                           :on-change #(reset! filter-input (.. % -target -value))}]
-            [:button.button.icon-button {:on-click save-query
-                                         :style {:margin 0}}
-             [components/icon-add]]
-            (if @input-error
-              [:div.input-error {:style {:color "red" :margin-top 5}}
-               "Please enter a valid number."])]
-           [:ul.filter-items
-             (map (fn [item]
-                      ^{:key (:id item)}
-                      [:li.filter-item
-                        [:button.button
-                          {:style {:margin 0}
-                           :on-click (fn [event] (swap! filter-items #(remove (comp (partial = (:query item)) :query) %)))}
-                          (:filter-type item) ": " [:span.filter-item-string (:query item)]
-                          [:span.icon-button [components/icon-remove]]]])
-                  @filter-items)]]
+          [:div.filter
+            [:div.filter-control
+              [:select {:value @filter-type
+                        :on-change #(reset! filter-type (keyword (.. % -target -value)))}
+                [:option {:value "contains"} "contains"]
+                [:option {:value "slower-than"} "slower than"]]
+              [:div.filter-control-input {:style {:margin-left 10}}
+                [search-input {:on-save save-query
+                               :on-change #(reset! filter-input (.. % -target -value))}]
+                [:button.button.icon-button {:on-click save-query
+                                             :style {:margin 0}}
+                 [components/icon-add]]
+                (if @input-error
+                  [:div.input-error {:style {:color "red" :margin-top 5}}
+                   "Please enter a valid number."])]]
+            [:ul.filter-items
+               (map (fn [item]
+                        ^{:key (:id item)}
+                        [:li.filter-item
+                          [:button.button
+                            {:style {:margin 0}
+                             :on-click (fn [event] (swap! filter-items #(remove (comp (partial = (:query item)) :query) %)))}
+                            (:filter-type item) ": " [:span.filter-item-string (:query item)]
+                            [:span.icon-button [components/icon-remove]]]])
+                    @filter-items)]]
          [components/autoscroll-list {:class "panel-content-scrollable" :scroll? true}
           [:table
            [:thead>tr

--- a/src/day8/re_frame/trace.cljs
+++ b/src/day8/re_frame/trace.cljs
@@ -278,8 +278,9 @@
                   (if (:show-all? @trace-detail-expansions) "-" "+")]]
             [:th "operations"]
             [:th
-              [:span {:class (str/join " " ["filter-items-count"
-                                            (when (pos? (count @filter-items)) "highlight")])}
+              [:button {:class (str/join " " ["filter-items-count"
+                                              (when (pos? (count @filter-items)) "active")])
+                        :on-click #(reset! filter-items [])}
                 (when (pos? (count @filter-items))
                   (str (count visible-traces) " of "))
                 (str (count @traces))]

--- a/src/day8/re_frame/trace.cljs
+++ b/src/day8/re_frame/trace.cljs
@@ -248,9 +248,7 @@
               [:div.filter-control-input {:style {:margin-left 10}}
                 [search-input {:on-save save-query
                                :on-change #(reset! filter-input (.. % -target -value))}]
-                [:button.button.icon-button {:on-click save-query
-                                             :style {:margin 0}}
-                 [components/icon-add]]
+                 [components/icon-add]
                 (if @input-error
                   [:div.input-error {:style {:color "red" :margin-top 5}}
                    "Please enter a valid number."])]]
@@ -261,8 +259,7 @@
                           [:button.button
                             {:style {:margin 0}
                              :on-click (fn [event] (swap! filter-items #(remove (comp (partial = (:query item)) :query) %)))}
-                            (:filter-type item) ": " [:span.filter-item-string (:query item)]
-                            [:span.icon-button [components/icon-remove]]]])
+                            (:filter-type item) ": " [:span.filter-item-string (:query item)]]])
                     @filter-items)]]
          [components/autoscroll-list {:class "panel-content-scrollable" :scroll? true}
           [:table

--- a/src/day8/re_frame/trace.cljs
+++ b/src/day8/re_frame/trace.cljs
@@ -257,8 +257,6 @@
                   @filter-items)]]
          [components/autoscroll-list {:class "panel-content-scrollable" :scroll? true}
           [:table
-           {:style {:margin-bottom 10}
-            :cell-spacing "0" :width "100%"}
            [:thead>tr
             [:th {:style {:padding 0}}
               [:button.text-button

--- a/src/day8/re_frame/trace.cljs
+++ b/src/day8/re_frame/trace.cljs
@@ -205,14 +205,16 @@
                             (when show-row?
                               [:tr.trace--details {:key (str id "-details")}
                                [:td]
-                               [:td.trace--details-tags {:col-span 4
+                               [:td.trace--details-tags {:col-span 2
                                                          :on-click #(.log js/console tags)}
                                  [:div.trace--details-tags-text
                                    (let [tag-str (with-out-str (pprint/pprint tags))
                                          string-size-limit 400]
                                         (if (< string-size-limit (count tag-str))
                                           (str (subs tag-str 0 string-size-limit) " ...")
-                                          tag-str))]]]))))))))
+                                          tag-str))]]
+                               [:td.trace--meta.trace--details-icon
+                                  {:on-click #(.log js/console tags)}]]))))))))
 (defn render-trace-panel []
   (let [filter-input               (r/atom "")
         filter-items               (r/atom (localstorage/get "filter-items" []))

--- a/src/day8/re_frame/trace.cljs
+++ b/src/day8/re_frame/trace.cljs
@@ -278,10 +278,11 @@
                   (if (:show-all? @trace-detail-expansions) "-" "+")]]
             [:th "operations"]
             [:th
-              (when (pos? (count @filter-items))
-                (str (count visible-traces) " of "))
-              (when (pos? (count @traces))
-                (str (count @traces)))
+              [:span {:class (str/join " " ["filter-items-count"
+                                            (when (pos? (count @filter-items)) "highlight")])}
+                (when (pos? (count @filter-items))
+                  (str (count visible-traces) " of "))
+                (str (count @traces))]
               " events "
               (when (pos? (count @traces))
                 [:span "(" [:button.text-button {:on-click #(do (trace/reset-tracing!) (reset! traces []))} "clear"] ")"])]


### PR DESCRIPTION
I wanted to make the traces table more readable, since I spend all day looking at it (:

- pick more calmer colours for the op names (still working on this, I'm still kinda iffy on this palette), and constrain the amount of colour -- the amount of colour felt distracting
- make sure the op name colours are accessible (AA standard)
- nudge the dropdown arrows closer to the op names
- style the trace details to convey more association with the trace that they're describing
- trace names are unlined on hover, to show that clicking on them has an effect

**before**

![old table](https://user-images.githubusercontent.com/1589186/30132638-5c786aac-9351-11e7-9c25-6f94ef5784ba.png)


**after**

![new table](https://user-images.githubusercontent.com/1589186/30132642-5e453554-9351-11e7-8467-6f3d9afbfd77.gif)
