### PR TITLE
Add trace filter by category

### DIFF
--- a/resources/day8/re_frame/trace/main.css
+++ b/resources/day8/re_frame/trace/main.css
@@ -394,3 +394,13 @@
 #--re-frame-trace-- .filter-items-count.active:hover {
   text-decoration: line-through;
 }
+#--re-frame-trace-- .filter-category {
+  display: inline-block;
+  background: #efeef1;
+  padding: 5px;
+  margin: 5px;
+  opacity: 0.3;
+}
+#--re-frame-trace-- .active {
+  opacity: 1;
+}

--- a/resources/day8/re_frame/trace/main.css
+++ b/resources/day8/re_frame/trace/main.css
@@ -397,6 +397,7 @@
 #--re-frame-trace-- .filter-category {
   display: inline-block;
   background: #efeef1;
+  cursor: pointer;
   padding: 5px;
   margin: 5px;
   opacity: 0.3;

--- a/resources/day8/re_frame/trace/main.css
+++ b/resources/day8/re_frame/trace/main.css
@@ -394,6 +394,9 @@
 #--re-frame-trace-- .filter-items-count.active:hover {
   text-decoration: line-through;
 }
+#--re-frame-trace-- .filter-fields {
+  margin-top: 10px;
+}
 #--re-frame-trace-- .filter-category {
   display: inline-block;
   background: #efeef1;

--- a/resources/day8/re_frame/trace/main.less
+++ b/resources/day8/re_frame/trace/main.less
@@ -503,4 +503,14 @@
       }
     }
   }
+  .filter-category {
+    display: inline-block;
+    background: #efeef1;
+    padding: 5px;
+    margin: 5px;
+    opacity: 0.3;
+  }
+  .active {
+    opacity: 1;
+  }
 }

--- a/resources/day8/re_frame/trace/main.less
+++ b/resources/day8/re_frame/trace/main.less
@@ -503,6 +503,9 @@
       }
     }
   }
+  .filter-fields {
+    margin-top: 10px;
+  }
   .filter-category {
     display: inline-block;
     background: #efeef1;

--- a/resources/day8/re_frame/trace/main.less
+++ b/resources/day8/re_frame/trace/main.less
@@ -506,6 +506,7 @@
   .filter-category {
     display: inline-block;
     background: #efeef1;
+    cursor: pointer;
     padding: 5px;
     margin: 5px;
     opacity: 0.3;

--- a/src/day8/re_frame/trace.cljs
+++ b/src/day8/re_frame/trace.cljs
@@ -230,9 +230,10 @@
                  (localstorage/save! "filter-items" new-state)))
     (fn []
       (let [toggle-category-fn   (fn [category-keys]
-                                   (swap! categories #(set (if (empty? (set/intersection % category-keys))
-                                                             (concat category-keys %)
-                                                             (remove category-keys %)))))
+                                   (swap! categories #(if (set/superset? % category-keys)
+                                                        (set/difference % category-keys)
+                                                        (set/union % category-keys))))
+
             visible-traces       (cond->> @traces
                                    (seq @categories)    (filter (fn [trace] (when (contains? @categories (:op-type trace)) trace)))
                                    (seq @filter-items)  (filter (apply every-pred (map query->fn @filter-items))))

--- a/src/day8/re_frame/trace.cljs
+++ b/src/day8/re_frame/trace.cljs
@@ -230,14 +230,14 @@
                  (localstorage/save! "filter-items" new-state)))
     (fn []
       (let [toggle-category-fn   (fn [category-keys]
-                                   (swap! categories #(set (if (empty? (set/intersection @categories category-keys))
-                                                             (concat category-keys @categories)
-                                                             (remove category-keys @categories)))))
+                                   (swap! categories #(set (if (empty? (set/intersection % category-keys))
+                                                             (concat category-keys %)
+                                                             (remove category-keys %)))))
             set-active           (fn [category]
                                    (when (contains? @categories category) "active"))
             visible-traces       (cond->> @traces
-                                   (not (empty? @categories))   (filter #(when (contains? @categories (:op-type %)) %))
-                                   (not (empty? @filter-items)) (filter (apply every-pred (map query->fn @filter-items))))
+                                   (not (empty? @categories))    (filter #(when (contains? @categories (:op-type %)) %))
+                                   (not (empty? @filter-items))  (filter (apply every-pred (map query->fn @filter-items))))
             save-query           (fn [_]
                                    (if (and (= @filter-type :slower-than)
                                             (js/isNaN (js/parseFloat @filter-input)))
@@ -260,15 +260,16 @@
                "re-frame"]
               [:li.filter-category {:class (set-active :render)
                                     :on-click #(toggle-category-fn #{:render :componentWillUnmount})}
-               "reagent"]
+               "reagent"]]
+             [:div
               [:select {:value @filter-type
                         :on-change #(reset! filter-type (keyword (.. % -target -value)))}
                 [:option {:value "contains"} "contains"]
                 [:option {:value "slower-than"} "slower than"]]
               [:div.filter-control-input {:style {:margin-left 10}}
                 [search-input {:on-save save-query
-                               :on-change #(reset! filter-input (.. % -target -value))}
-                 [components/icon-add]]
+                               :on-change #(reset! filter-input (.. % -target -value))}]
+                [components/icon-add]
                 (if @input-error
                   [:div.input-error {:style {:color "red" :margin-top 5}}
                    "Please enter a valid number."])]]]

--- a/src/day8/re_frame/trace.cljs
+++ b/src/day8/re_frame/trace.cljs
@@ -233,10 +233,8 @@
                                    (swap! categories #(set (if (empty? (set/intersection % category-keys))
                                                              (concat category-keys %)
                                                              (remove category-keys %)))))
-            set-active           (fn [category]
-                                   (when (contains? @categories category) "active"))
             visible-traces       (cond->> @traces
-                                   (seq @categories)    (filter #(when (contains? @categories (:op-type %)) %))
+                                   (seq @categories)    (filter (fn [trace] (when (contains? @categories (:op-type trace)) trace)))
                                    (seq @filter-items)  (filter (apply every-pred (map query->fn @filter-items))))
             save-query           (fn [_]
                                    (if (and (= @filter-type :slower-than)
@@ -249,19 +247,19 @@
           [:div.filter
             [:div.filter-control
              [:ul.filter-categories "show: "
-              [:li.filter-category {:class (set-active :event)
+              [:li.filter-category {:class (when (contains? @categories :event) "active")
                                     :on-click #(toggle-category-fn #{:event})}
                "events"]
-              [:li.filter-category {:class (set-active :sub/run)
+              [:li.filter-category {:class (when (contains? @categories :sub/run) "active")
                                     :on-click #(toggle-category-fn #{:sub/run :sub/create})}
                "subscriptions"]
-              [:li.filter-category {:class (set-active :re-frame.router/fsm-trigger)
-                                    :on-click #(toggle-category-fn #{:re-frame.router/fsm-trigger})}
-               "re-frame"]
-              [:li.filter-category {:class (set-active :render)
-                                    :on-click #(toggle-category-fn #{:render :componentWillUnmount})}
-               "reagent"]]
-             [:div
+              [:li.filter-category {:class (when (contains? @categories :render) "active")
+                                    :on-click #(toggle-category-fn #{:render})}
+               "reagent"]
+              [:li.filter-category {:class (when (contains? @categories :re-frame.router/fsm-trigger) "active")
+                                    :on-click #(toggle-category-fn #{:re-frame.router/fsm-trigger :componentWillUnmount})}
+               "internals"]]
+             [:div.filter-fields
               [:select {:value @filter-type
                         :on-change #(reset! filter-type (keyword (.. % -target -value)))}
                 [:option {:value "contains"} "contains"]

--- a/src/day8/re_frame/trace.cljs
+++ b/src/day8/re_frame/trace.cljs
@@ -236,8 +236,8 @@
             set-active           (fn [category]
                                    (when (contains? @categories category) "active"))
             visible-traces       (cond->> @traces
-                                   (not (empty? @categories))    (filter #(when (contains? @categories (:op-type %)) %))
-                                   (not (empty? @filter-items))  (filter (apply every-pred (map query->fn @filter-items))))
+                                   (seq @categories)    (filter #(when (contains? @categories (:op-type %)) %))
+                                   (seq @filter-items)  (filter (apply every-pred (map query->fn @filter-items))))
             save-query           (fn [_]
                                    (if (and (= @filter-type :slower-than)
                                             (js/isNaN (js/parseFloat @filter-input)))


### PR DESCRIPTION
- enable filtering traces by category
- four possible categories: 
    - events (`:event`)
    - subscriptions (`:sub/run` `:sub/create`)
    - re-frame (`:re-frame.router/fsm-trigger` `:componentWillUnmount`)
    - reagent (`:render`)
- set default to show only events and subscriptions

- fixes #39
- fixes #57