### PR TITLE
app-state tab with cljs-devtools formatting

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,8 @@
                  [org.clojure/clojurescript  "1.9.227"]
                  [reagent                    "0.6.0"]
                  [re-frame                   "0.9.0"]
-                 [cljsjs/d3 "4.2.2-0"]]
+                 [cljsjs/d3                  "4.2.2-0"]
+                 [binaryage/devtools         "0.9.4"]]
   :plugins [[lein-less "1.7.5"]]
   :deploy-repositories {"releases" :clojars
                         "snapshots" :clojars}

--- a/resources/day8/re_frame/trace/main.css
+++ b/resources/day8/re_frame/trace/main.css
@@ -162,6 +162,14 @@
 #--re-frame-trace-- table {
   display: table;
 }
+#--re-frame-trace-- th,
+#--re-frame-trace-- td {
+  display: table-cell;
+  padding: 0 5px;
+}
+#--re-frame-trace-- tr {
+  display: table-row;
+}
 #--re-frame-trace-- thead {
   display: table-header-group;
 }

--- a/resources/day8/re_frame/trace/main.css
+++ b/resources/day8/re_frame/trace/main.css
@@ -457,3 +457,11 @@
   color: #8f8f8f;
   content: "}";
 }
+#--re-frame-trace-- .re-frame-trace--object:before {
+  color: #8f8f8f;
+  content: "▶ ";
+}
+#--re-frame-trace-- .re-frame-trace--object:after {
+  color: #222222;
+  content: "{...}";
+}

--- a/resources/day8/re_frame/trace/main.css
+++ b/resources/day8/re_frame/trace/main.css
@@ -457,6 +457,9 @@
   color: #8f8f8f;
   content: "}";
 }
+#--re-frame-trace-- .re-frame-trace--object {
+  display: block;
+}
 #--re-frame-trace-- .re-frame-trace--object:before {
   color: #8f8f8f;
   content: "▶ ";

--- a/resources/day8/re_frame/trace/main.css
+++ b/resources/day8/re_frame/trace/main.css
@@ -457,6 +457,9 @@
   color: #8f8f8f;
   content: "}";
 }
+#--re-frame-trace-- .re-frame-trace--object {
+  display: block;
+}
 #--re-frame-trace-- .re-frame-trace--object .toggle {
   color: #8f8f8f;
   cursor: pointer;

--- a/resources/day8/re_frame/trace/main.css
+++ b/resources/day8/re_frame/trace/main.css
@@ -321,11 +321,15 @@
   border-radius: 0;
   padding-bottom: 1px;
 }
-#--re-frame-trace-- ul.filter-items {
+#--re-frame-trace-- ul.filter-items,
+#--re-frame-trace-- .subtrees {
   list-style-type: none;
   margin: 0 5px;
 }
-#--re-frame-trace-- ul.filter-items .filter-item {
+#--re-frame-trace-- ul.filter-items .filter-item,
+#--re-frame-trace-- .subtrees .filter-item,
+#--re-frame-trace-- ul.filter-items .subtree-button,
+#--re-frame-trace-- .subtrees .subtree-button {
   color: #8f8f8f;
   background: #fafafa;
   border: 1px solid #efeef1;
@@ -333,11 +337,23 @@
   font-size: 0.9em;
   margin: 10px 5px;
 }
-#--re-frame-trace-- ul.filter-items .filter-item .filter-item-string {
+#--re-frame-trace-- ul.filter-items .filter-item .filter-item-string,
+#--re-frame-trace-- .subtrees .filter-item .filter-item-string,
+#--re-frame-trace-- ul.filter-items .subtree-button .filter-item-string,
+#--re-frame-trace-- .subtrees .subtree-button .filter-item-string {
   color: #222222;
   background: #ffff00;
 }
-#--re-frame-trace-- ul.filter-items .filter-item:hover {
+#--re-frame-trace-- ul.filter-items .filter-item .subtree-button-string,
+#--re-frame-trace-- .subtrees .filter-item .subtree-button-string,
+#--re-frame-trace-- ul.filter-items .subtree-button .subtree-button-string,
+#--re-frame-trace-- .subtrees .subtree-button .subtree-button-string {
+  color: #222222;
+}
+#--re-frame-trace-- ul.filter-items .filter-item:hover,
+#--re-frame-trace-- .subtrees .filter-item:hover,
+#--re-frame-trace-- ul.filter-items .subtree-button:hover,
+#--re-frame-trace-- .subtrees .subtree-button:hover {
   text-decoration: line-through;
 }
 #--re-frame-trace-- .icon {
@@ -465,5 +481,16 @@
   cursor: pointer;
 }
 #--re-frame-trace-- .re-frame-trace--object > span {
+  vertical-align: text-top;
+}
+#--re-frame-trace-- .data-structure-editable.string:before {
+  color: #8f8f8f;
+  content: "\"";
+}
+#--re-frame-trace-- .data-structure-editable.string:after {
+  color: #8f8f8f;
+  content: "\"";
+}
+#--re-frame-trace-- .data-structure-editable > span {
   vertical-align: text-top;
 }

--- a/resources/day8/re_frame/trace/main.css
+++ b/resources/day8/re_frame/trace/main.css
@@ -22,6 +22,9 @@
      ========================================================================== */
   background: white;
   font-family: 'courier new', monospace;
+  color: #222222;
+  /* app-state data viewer
+     ========================================================================== */
 }
 #--re-frame-trace-- * {
   all: unset;
@@ -415,4 +418,42 @@
 }
 #--re-frame-trace-- .active {
   opacity: 1;
+}
+#--re-frame-trace-- .re-frame-trace--collection {
+  border-left: 1px solid #efeef1;
+  margin-left: 10px;
+  padding-left: 10px;
+}
+#--re-frame-trace-- .re-frame-trace--primative:not(:first-child) {
+  margin-left: 10px;
+}
+#--re-frame-trace-- .re-frame-trace--boolean {
+  font-style: italic;
+}
+#--re-frame-trace-- .re-frame-trace--string:before {
+  color: #8f8f8f;
+  content: "\"";
+}
+#--re-frame-trace-- .re-frame-trace--string:after {
+  color: #8f8f8f;
+  content: "\"";
+}
+#--re-frame-trace-- .re-frame-trace--nil {
+  text-decoration: line-through;
+  font-style: italic;
+}
+#--re-frame-trace-- .re-frame-trace--keyword {
+  color: #616cdb;
+}
+#--re-frame-trace-- .re-frame-trace--cljs-core-PersistentArrayMap:before,
+#--re-frame-trace-- .re-frame-trace--cljs-core-PersistentTreeMap:before,
+#--re-frame-trace-- .re-frame-trace--cljs-core-PersistentVector:before {
+  color: #8f8f8f;
+  content: "{";
+}
+#--re-frame-trace-- .re-frame-trace--cljs-core-PersistentArrayMap:after,
+#--re-frame-trace-- .re-frame-trace--cljs-core-PersistentTreeMap:after,
+#--re-frame-trace-- .re-frame-trace--cljs-core-PersistentVector:after {
+  color: #8f8f8f;
+  content: "}";
 }

--- a/resources/day8/re_frame/trace/main.css
+++ b/resources/day8/re_frame/trace/main.css
@@ -23,6 +23,7 @@
   background: white;
   font-family: 'courier new', monospace;
   color: #222222;
+  /* mixins */
   /* app-state data viewer
      ========================================================================== */
 }
@@ -186,6 +187,14 @@
 #--re-frame-trace-- tr {
   display: table-row;
 }
+#--re-frame-trace-- .label {
+  color: #8f8f8f;
+  background: #fafafa;
+  border: 1px solid #efeef1;
+  font-size: 0.9em;
+  margin: 10px 5px;
+  color: #222222;
+}
 #--re-frame-trace-- table {
   width: 100%;
   font-size: 14px;
@@ -333,9 +342,10 @@
   color: #8f8f8f;
   background: #fafafa;
   border: 1px solid #efeef1;
-  display: inline-block;
   font-size: 0.9em;
   margin: 10px 5px;
+  color: #222222;
+  display: inline-block;
 }
 #--re-frame-trace-- ul.filter-items .filter-item .filter-item-string,
 #--re-frame-trace-- .subtrees .filter-item .filter-item-string,

--- a/resources/day8/re_frame/trace/main.css
+++ b/resources/day8/re_frame/trace/main.css
@@ -457,10 +457,10 @@
   color: #8f8f8f;
   content: "}";
 }
-#--re-frame-trace-- .re-frame-trace--object {
-  display: block;
-}
 #--re-frame-trace-- .re-frame-trace--object:before {
   color: #8f8f8f;
   content: "▶ ";
+}
+#--re-frame-trace-- .re-frame-trace--object > span {
+  vertical-align: text-top;
 }

--- a/resources/day8/re_frame/trace/main.css
+++ b/resources/day8/re_frame/trace/main.css
@@ -363,7 +363,11 @@
 #--re-frame-trace-- ul.filter-items .filter-item:hover,
 #--re-frame-trace-- .subtrees .filter-item:hover,
 #--re-frame-trace-- ul.filter-items .subtree-button:hover,
-#--re-frame-trace-- .subtrees .subtree-button:hover {
+#--re-frame-trace-- .subtrees .subtree-button:hover,
+#--re-frame-trace-- ul.filter-items .filter-item:focus,
+#--re-frame-trace-- .subtrees .filter-item:focus,
+#--re-frame-trace-- ul.filter-items .subtree-button:focus,
+#--re-frame-trace-- .subtrees .subtree-button:focus {
   text-decoration: line-through;
 }
 #--re-frame-trace-- .icon {

--- a/resources/day8/re_frame/trace/main.css
+++ b/resources/day8/re_frame/trace/main.css
@@ -457,13 +457,9 @@
   color: #8f8f8f;
   content: "}";
 }
-#--re-frame-trace-- .re-frame-trace--object:before {
+#--re-frame-trace-- .re-frame-trace--object .toggle {
   color: #8f8f8f;
-  content: "▶ ";
-}
-#--re-frame-trace-- .re-frame-trace--object.expanded:before {
-  color: #8f8f8f;
-  content: "▼ ";
+  cursor: pointer;
 }
 #--re-frame-trace-- .re-frame-trace--object > span {
   vertical-align: text-top;

--- a/resources/day8/re_frame/trace/main.css
+++ b/resources/day8/re_frame/trace/main.css
@@ -461,6 +461,10 @@
   color: #8f8f8f;
   content: "▶ ";
 }
+#--re-frame-trace-- .re-frame-trace--object.expanded:before {
+  color: #8f8f8f;
+  content: "▼ ";
+}
 #--re-frame-trace-- .re-frame-trace--object > span {
   vertical-align: text-top;
 }

--- a/resources/day8/re_frame/trace/main.css
+++ b/resources/day8/re_frame/trace/main.css
@@ -461,7 +461,3 @@
   color: #8f8f8f;
   content: "▶ ";
 }
-#--re-frame-trace-- .re-frame-trace--object:after {
-  color: #222222;
-  content: "{...}";
-}

--- a/resources/day8/re_frame/trace/main.less
+++ b/resources/day8/re_frame/trace/main.less
@@ -214,6 +214,13 @@
   table {
     display: table;
   }
+  th, td {
+    display: table-cell;
+    padding: 0 5px;
+  }
+  tr {
+    display: table-row;
+  }
   thead {
     display: table-header-group;
   }

--- a/resources/day8/re_frame/trace/main.less
+++ b/resources/day8/re_frame/trace/main.less
@@ -580,6 +580,10 @@
       color: @text-color-muted;
       content: "▶ ";
     }
-    display: block;
+    // display: block;
+
+    &>span {
+      vertical-align: text-top;
+    }
   }
 }

--- a/resources/day8/re_frame/trace/main.less
+++ b/resources/day8/re_frame/trace/main.less
@@ -580,9 +580,5 @@
       color: @text-color-muted;
       content: "▶ ";
     }
-    &:after {
-      color: @text-color;
-      content: "{...}";
-    }
   }
 }

--- a/resources/day8/re_frame/trace/main.less
+++ b/resources/day8/re_frame/trace/main.less
@@ -413,11 +413,13 @@
     border-radius: 0;
     padding-bottom: 1px;
   }
-  ul.filter-items {
+  ul.filter-items,
+  .subtrees {
     list-style-type: none;
     margin: 0 5px;
 
-    .filter-item {
+    .filter-item,
+    .subtree-button {
       color: @text-color-muted;
       background: @background-gray-hint;
       border: 1px solid @light-gray;
@@ -428,6 +430,10 @@
       .filter-item-string {
         color: @text-color;
         background: @yellow;
+      }
+
+      .subtree-button-string {
+        color: @text-color;
       }
 
       &:hover {

--- a/resources/day8/re_frame/trace/main.less
+++ b/resources/day8/re_frame/trace/main.less
@@ -580,7 +580,12 @@
       color: @text-color-muted;
       content: "▶ ";
     }
-    // display: block;
+    &.expanded {
+      &:before {
+        color: @text-color-muted;
+        content: "▼ ";
+      }
+    }
 
     &>span {
       vertical-align: text-top;

--- a/resources/day8/re_frame/trace/main.less
+++ b/resources/day8/re_frame/trace/main.less
@@ -241,6 +241,7 @@
 
   background: white;
   font-family: 'courier new', monospace;
+  color: @text-color;
 
   table {
     width: 100%;
@@ -523,5 +524,55 @@
   }
   .active {
     opacity: 1;
+  }
+
+  /* app-state data viewer
+     ========================================================================== */
+
+  .re-frame-trace--collection {
+    border-left: 1px solid @light-gray;
+    margin-left: 10px;
+    padding-left: 10px;
+    // background: rgba(0, 0, 0, 0.07);
+  }
+  .re-frame-trace--primative:not(:first-child) {
+    margin-left: 10px;
+    // color: @text-color-muted;
+  }
+  .re-frame-trace--number {
+  }
+  .re-frame-trace--boolean {
+    font-style: italic;
+  }
+  .re-frame-trace--string {
+    &:before {
+      color: @text-color-muted;
+      content: "\"";
+    }
+    &:after {
+      color: @text-color-muted;
+      content: "\"";
+    }
+  }
+  .re-frame-trace--nil {
+    text-decoration: line-through;
+    font-style: italic;
+  }
+  .re-frame-trace--keyword {
+    color: @light-purple;
+  }
+  .re-frame-trace--symbol {
+  }
+  .re-frame-trace--cljs-core-PersistentArrayMap,
+  .re-frame-trace--cljs-core-PersistentTreeMap,
+  .re-frame-trace--cljs-core-PersistentVector {
+    &:before {
+      color: @text-color-muted;
+      content: "{";
+    }
+    &:after {
+      color: @text-color-muted;
+      content: "}";
+    }
   }
 }

--- a/resources/day8/re_frame/trace/main.less
+++ b/resources/day8/re_frame/trace/main.less
@@ -576,14 +576,23 @@
     }
   }
   .re-frame-trace--object {
-    &:before {
+    .toggle {
       color: @text-color-muted;
-      content: "▶ ";
+      cursor: pointer;
     }
-    &.expanded {
+    &>span {
+      vertical-align: text-top;
+    }
+  }
+  .data-structure-editable {
+    &.string {
       &:before {
         color: @text-color-muted;
-        content: "▼ ";
+        content: "\"";
+      }
+      &:after {
+        color: @text-color-muted;
+        content: "\"";
       }
     }
 

--- a/resources/day8/re_frame/trace/main.less
+++ b/resources/day8/re_frame/trace/main.less
@@ -575,4 +575,14 @@
       content: "}";
     }
   }
+  .re-frame-trace--object {
+    &:before {
+      color: @text-color-muted;
+      content: "▶ ";
+    }
+    &:after {
+      color: @text-color;
+      content: "{...}";
+    }
+  }
 }

--- a/resources/day8/re_frame/trace/main.less
+++ b/resources/day8/re_frame/trace/main.less
@@ -243,6 +243,16 @@
   font-family: 'courier new', monospace;
   color: @text-color;
 
+  /* mixins */
+  .label {
+    color: @text-color-muted;
+    background: @background-gray-hint;
+    border: 1px solid @light-gray;
+    font-size: 0.9em;
+    margin: 10px 5px;
+    color: @text-color;
+  }
+
   table {
     width: 100%;
     font-size: 14px;
@@ -420,12 +430,8 @@
 
     .filter-item,
     .subtree-button {
-      color: @text-color-muted;
-      background: @background-gray-hint;
-      border: 1px solid @light-gray;
+      .label;
       display: inline-block;
-      font-size: 0.9em;
-      margin: 10px 5px;
 
       .filter-item-string {
         color: @text-color;

--- a/resources/day8/re_frame/trace/main.less
+++ b/resources/day8/re_frame/trace/main.less
@@ -580,5 +580,6 @@
       color: @text-color-muted;
       content: "▶ ";
     }
+    display: block;
   }
 }

--- a/resources/day8/re_frame/trace/main.less
+++ b/resources/day8/re_frame/trace/main.less
@@ -442,7 +442,8 @@
         color: @text-color;
       }
 
-      &:hover {
+      &:hover,
+      &:focus {
         text-decoration: line-through;
       }
     }

--- a/resources/day8/re_frame/trace/main.less
+++ b/resources/day8/re_frame/trace/main.less
@@ -576,6 +576,7 @@
     }
   }
   .re-frame-trace--object {
+    display: block;
     .toggle {
       color: @text-color-muted;
       cursor: pointer;

--- a/src/day8/re_frame/trace.cljs
+++ b/src/day8/re_frame/trace.cljs
@@ -394,7 +394,6 @@
                                           :subvis [subvis/render-subvis traces
                                                     [:div.panel-content-scrollable]]
                                           :app-state [app-state/tab @db/app-db])]]]))})))
-
 (defn panel-div []
   (let [id    "--re-frame-trace--"
         panel (.getElementById js/document id)]

--- a/src/day8/re_frame/trace.cljs
+++ b/src/day8/re_frame/trace.cljs
@@ -268,7 +268,6 @@
               [:div.filter-control-input {:style {:margin-left 10}}
                 [search-input {:on-save save-query
                                :on-change #(reset! filter-input (.. % -target -value))}]
-                [components/icon-add]
                 (if @input-error
                   [:div.input-error {:style {:color "red" :margin-top 5}}
                    "Please enter a valid number."])]]]

--- a/src/day8/re_frame/trace.cljs
+++ b/src/day8/re_frame/trace.cljs
@@ -325,7 +325,7 @@
         showing?          (r/atom (localstorage/get "show-panel" false))
         dragging?         (r/atom false)
         pin-to-bottom?    (r/atom true)
-        selected-tab      (r/atom :traces)
+        selected-tab      (r/atom (localstorage/get "selected-tab" :traces))
         window-width      js/window.innerWidth
         handle-keys       (fn [e]
                            (let [combo-key?      (or (.-ctrlKey e) (.-metaKey e) (.-altKey e))
@@ -353,6 +353,10 @@
                :update-show-panel
                (fn [_ _ _ new-state]
                  (localstorage/save! "show-panel" new-state)))
+    (add-watch selected-tab
+               :update-selected-tab
+               (fn [_ _ _ new-state]
+                 (localstorage/save! "selected-tab" new-state)))
     (r/create-class
       {:component-will-mount   (fn []
                                  (toggle-traces showing?)

--- a/src/day8/re_frame/trace.cljs
+++ b/src/day8/re_frame/trace.cljs
@@ -389,15 +389,16 @@
                                           [:div.nav
                                             [:button {:class (str "tab button " (when (= @selected-tab :traces) "active"))
                                                       :on-click #(reset! selected-tab :traces)} "Traces"]
-                                            [:button {:class (str "tab button " (when (= @selected-tab :subvis) "active"))
-                                                      :on-click #(reset! selected-tab :subvis)} "SubVis"]
                                             [:button {:class (str "tab button " (when (= @selected-tab :app-state) "active"))
-                                                      :on-click #(reset! selected-tab :app-state)} "app-state"]]]
+                                                      :on-click #(reset! selected-tab :app-state)} "app-state"]
+                                            [:button {:class (str "tab button " (when (= @selected-tab :subvis) "active"))
+                                                      :on-click #(reset! selected-tab :subvis)} "SubVis"]]]
                                         (case @selected-tab
                                           :traces [render-trace-panel]
+                                          :app-state [app-state/render-state db/app-db]
                                           :subvis [subvis/render-subvis traces
-                                                    [:div.panel-content-scrollable]]
-                                          :app-state [app-state/render-state db/app-db])]]]))})))
+                                                    [:div.panel-content-scrollable]])]]]))})))
+
 (defn panel-div []
   (let [id    "--re-frame-trace--"
         panel (.getElementById js/document id)]

--- a/src/day8/re_frame/trace.cljs
+++ b/src/day8/re_frame/trace.cljs
@@ -1,5 +1,6 @@
 (ns day8.re-frame.trace
   (:require [day8.re-frame.trace.subvis :as subvis]
+            [day8.re-frame.trace.app-state :as app-state]
             [day8.re-frame.trace.styles :as styles]
             [day8.re-frame.trace.components :as components]
             [day8.re-frame.trace.localstorage :as localstorage]
@@ -386,11 +387,14 @@
                                             [:button {:class (str "tab button " (when (= @selected-tab :traces) "active"))
                                                       :on-click #(reset! selected-tab :traces)} "Traces"]
                                             [:button {:class (str "tab button " (when (= @selected-tab :subvis) "active"))
-                                                      :on-click #(reset! selected-tab :subvis)} "SubVis"]]]
+                                                      :on-click #(reset! selected-tab :subvis)} "SubVis"]
+                                            [:button {:class (str "tab button " (when (= @selected-tab :app-state) "active"))
+                                                      :on-click #(reset! selected-tab :app-state)} "app-state"]]]
                                         (case @selected-tab
                                           :traces [render-trace-panel]
                                           :subvis [subvis/render-subvis traces
-                                                    [:div.panel-content-scrollable]])]]]))})))
+                                                    [:div.panel-content-scrollable]]
+                                          :app-state [app-state/tab @traces])]]]))})))
 
 (defn panel-div []
   (let [id    "--re-frame-trace--"

--- a/src/day8/re_frame/trace.cljs
+++ b/src/day8/re_frame/trace.cljs
@@ -5,6 +5,7 @@
             [day8.re-frame.trace.components :as components]
             [day8.re-frame.trace.localstorage :as localstorage]
             [re-frame.trace :as trace :include-macros true]
+            [re-frame.db :as db]
             [cljs.pprint :as pprint]
             [clojure.string :as str]
             [clojure.set :as set]
@@ -26,8 +27,6 @@
     (if-not (empty? n)
       n
       "")))
-
-
 
 (def static-fns
   {:render
@@ -394,7 +393,7 @@
                                           :traces [render-trace-panel]
                                           :subvis [subvis/render-subvis traces
                                                     [:div.panel-content-scrollable]]
-                                          :app-state [app-state/tab @traces])]]]))})))
+                                          :app-state [app-state/tab @db/app-db])]]]))})))
 
 (defn panel-div []
   (let [id    "--re-frame-trace--"

--- a/src/day8/re_frame/trace.cljs
+++ b/src/day8/re_frame/trace.cljs
@@ -120,24 +120,6 @@
   []
   (monkey-patch-reagent))
 
-
-(defn search-input [{:keys [title on-save on-change on-stop]}]
-  (let [val  (r/atom title)
-        save #(let [v (-> @val str str/trim)]
-                (when (pos? (count v))
-                  (on-save v)))]
-    (fn []
-      [:input {:type        "text"
-               :value       @val
-               :auto-focus  true
-               :on-change   #(do (reset! val (-> % .-target .-value))
-                                 (on-change %))
-               :on-key-down #(case (.-which %)
-                               13 (do
-                                    (save)
-                                    (reset! val ""))
-                               nil)}])))
-
 (defn query->fn [query]
   (if (= :contains (:filter-type query))
     (fn [trace]
@@ -266,8 +248,8 @@
                 [:option {:value "contains"} "contains"]
                 [:option {:value "slower-than"} "slower than"]]
               [:div.filter-control-input {:style {:margin-left 10}}
-                [search-input {:on-save save-query
-                               :on-change #(reset! filter-input (.. % -target -value))}]
+                [components/search-input {:on-save save-query
+                                          :on-change #(reset! filter-input (.. % -target -value))}]
                 (if @input-error
                   [:div.input-error {:style {:color "red" :margin-top 5}}
                    "Please enter a valid number."])]]]

--- a/src/day8/re_frame/trace.cljs
+++ b/src/day8/re_frame/trace.cljs
@@ -397,7 +397,7 @@
                                           :traces [render-trace-panel]
                                           :subvis [subvis/render-subvis traces
                                                     [:div.panel-content-scrollable]]
-                                          :app-state [app-state/tab @db/app-db])]]]))})))
+                                          :app-state [app-state/render-state db/app-db])]]]))})))
 (defn panel-div []
   (let [id    "--re-frame-trace--"
         panel (.getElementById js/document id)]

--- a/src/day8/re_frame/trace/app_state.cljs
+++ b/src/day8/re_frame/trace/app_state.cljs
@@ -1,16 +1,34 @@
 (ns day8.re-frame.trace.app-state
   (:require [reagent.core :as r]
-            [clojure.string :as str]))
+            [clojure.string :as str]
 
-(defn classname
+            [cljs.pprint :refer [pprint]]))
+
+
+(defn css-munge
+  [string]
+  (str/replace string #"\.|/" "-"))
+
+(defn namespace-css
+  [classname]
+  (str "re-frame-trace--" classname))
+
+(defn type-string
   [obj]
-  (str/replace (pr-str (type obj)) #"\.|/" "-"))
+  (cond
+    (number? obj)    "number"
+    (boolean? obj)   "boolean"
+    (string? obj)    "string"
+    (nil? obj)       "nil"
+    (keyword? obj)   "keyword"
+    (symbol? obj)    "symbol"
+    :else (pr-str (type obj))))
 
 (defn view
   [data]
-  (if (string? data)
-    [:span.data-string data]
-    [:div {:class (classname data)}]))
+  (if (coll? data)
+    [:div {:class (str (namespace-css "collection") " " (namespace-css (css-munge (type-string data))))}]
+    [:span {:class (namespace-css (css-munge (type-string data)))} (str data)]))
 
 (defn crawl
   [data]
@@ -19,5 +37,8 @@
     (view data)))
 
 (defn tab [data]
-  (println (crawl data))
-  (crawl data))
+  (pprint data)
+  (pprint (crawl data))
+  [:div {:style {:flex "1 0 auto" :width "100%" :height "100%" :display "flex" :flex-direction "column"}}
+    [:div.panel-content-scrollable
+     (crawl data)]])

--- a/src/day8/re_frame/trace/app_state.cljs
+++ b/src/day8/re_frame/trace/app_state.cljs
@@ -27,8 +27,8 @@
 (defn view
   [data]
   (if (coll? data)
-    [:div {:class (str (namespace-css "collection") " " (namespace-css (css-munge (type-string data))))}]
-    [:span {:class (namespace-css (css-munge (type-string data)))} (str data)]))
+    [:div  {:class (str (namespace-css "collection") " " (namespace-css (css-munge (type-string data))))}]
+    [:span {:class (str (namespace-css "primative") " " (namespace-css (css-munge (type-string data))))} (str data)]))
 
 (defn crawl
   [data]
@@ -37,8 +37,6 @@
     (view data)))
 
 (defn tab [data]
-  (pprint data)
-  (pprint (crawl data))
   [:div {:style {:flex "1 0 auto" :width "100%" :height "100%" :display "flex" :flex-direction "column"}}
     [:div.panel-content-scrollable
      (crawl data)]])

--- a/src/day8/re_frame/trace/app_state.cljs
+++ b/src/day8/re_frame/trace/app_state.cljs
@@ -1,0 +1,23 @@
+(ns day8.re-frame.trace.app-state
+  (:require [reagent.core :as r]
+            [clojure.string :as str]))
+
+(defn classname
+  [obj]
+  (str/replace (pr-str (type obj)) #"\.|/" "-"))
+
+(defn view
+  [data]
+  (if (string? data)
+    [:span.data-string data]
+    [:div {:class (classname data)}]))
+
+(defn crawl
+  [data]
+  (if (coll? data)
+    (into (view data) (mapv crawl data))
+    (view data)))
+
+(defn tab [data]
+  (println (crawl data))
+  (crawl data))

--- a/src/day8/re_frame/trace/app_state.cljs
+++ b/src/day8/re_frame/trace/app_state.cljs
@@ -1,9 +1,9 @@
 (ns day8.re-frame.trace.app-state
   (:require [reagent.core :as r]
             [clojure.string :as str]
+            [devtools.formatters.core :as cljs-devtools]
 
             [cljs.pprint :refer [pprint]]))
-
 
 (defn css-munge
   [string]
@@ -30,13 +30,38 @@
     [:div  {:class (str (namespace-css "collection") " " (namespace-css (css-munge (type-string data))))}]
     [:span {:class (str (namespace-css "primative") " " (namespace-css (css-munge (type-string data))))} (str data)]))
 
+(defn jsonml-style
+  [style-map]
+  ; {:style (get style-map "style")}
+  {:style {:background "rgba(0,0,0,0.1)"}})
+
+(defn str->hiccup
+  [string]
+  ; (println string)
+  (cond (= string "span")  :span
+        (= string "style") :style
+        ; (= string "}")     nil
+        ; (= string "{")     nil
+        ; (= string " ")     nil
+        ; (= string ", ")    nil
+        :else              string))
+
+
 (defn crawl
   [data]
   (if (coll? data)
     (into (view data) (mapv crawl data))
     (view data)))
 
+(defn jsonml->hiccup
+  [data]
+  (cond
+    (vector? data) (mapv jsonml->hiccup data)
+    (map? data)    (jsonml-style data)
+    :else          (str->hiccup data)))
+
 (defn tab [data]
   [:div {:style {:flex "1 0 auto" :width "100%" :height "100%" :display "flex" :flex-direction "column"}}
     [:div.panel-content-scrollable
-     (crawl data)]])
+      (jsonml->hiccup (js->clj (cljs-devtools/header-api-call data)))]])
+      ; (crawl data)]])

--- a/src/day8/re_frame/trace/app_state.cljs
+++ b/src/day8/re_frame/trace/app_state.cljs
@@ -36,14 +36,15 @@
   (if (number? jsonml)
     jsonml
     (let [[head & args]             jsonml
-          tagnames                  #{"span" "ol" "li" "div"}]
+          tagnames                  #{"div" "span" "ol" "li" "table" "tr" "td"}]
       (cond
         (contains? tagnames head)   (let [[style & children] args]
-                                      [(keyword head) {:style (-> (js->clj style)
-                                                                  (get "style")
-                                                                  (string->css))}
-                                       (into [:div {:style {:display "inline-block"}}]
-                                             (mapv jsonml->hiccup children))])
+                                      (into
+                                        [(keyword head) {:style (-> (js->clj style)
+                                                                    (get "style")
+                                                                    (string->css))}]
+                                        (map jsonml->hiccup children)))
+
         (= head "object")           [data-structure jsonml]
         (= jsonml ", ")             " "
         :else jsonml))))

--- a/src/day8/re_frame/trace/app_state.cljs
+++ b/src/day8/re_frame/trace/app_state.cljs
@@ -48,17 +48,30 @@
     (into (view data) (mapv crawl data))
     (view data)))
 
+(declare jsonml->hiccup)
+
+(defn data-structure
+  [jsonml]
+  (let [expand? (r/atom true)]
+    (fn []
+      [:span.re-frame-trace--object
+        {:on-click #(swap! expand? not)}
+        (jsonml->hiccup (if @expand?
+                          (cljs-devtools/body-api-call
+                            (.-object (get jsonml 1))
+                            (.-config (get jsonml 1)))
+                          (cljs-devtools/header-api-call
+                            (.-object (get jsonml 1))
+                            (.-config (get jsonml 1)))))])))
+
 (defn jsonml->hiccup
   [jsonml]
   (cond
-    (array? jsonml)    (if (= "object" (get jsonml 0))
-                         [:span.re-frame-trace--object
-                           (jsonml->hiccup (cljs-devtools/body-api-call
-                                             (.-object (get jsonml 1))
-                                             (.-config (get jsonml 1))))]
-                         (mapv jsonml->hiccup jsonml))
-    (object? jsonml)   {:style (string->css (js->clj jsonml))}
-    :else              (str->hiccup jsonml)))
+    (and (array? jsonml)
+         (= "object" (get jsonml 0))) [data-structure jsonml]
+    (array? jsonml)                   (mapv jsonml->hiccup jsonml)
+    (object? jsonml)                  {:style (string->css (js->clj jsonml))}
+    :else                             (str->hiccup jsonml)))
 
 (defn tab [data]
   [:div {:style {:flex "1 0 auto" :width "100%" :height "100%" :display "flex" :flex-direction "column"}}

--- a/src/day8/re_frame/trace/app_state.cljs
+++ b/src/day8/re_frame/trace/app_state.cljs
@@ -30,14 +30,16 @@
     [:div  {:class (str (namespace-css "collection") " " (namespace-css (css-munge (type-string data))))}]
     [:span {:class (str (namespace-css "primative") " " (namespace-css (css-munge (type-string data))))} (str data)]))
 
-(defn jsonml-style
-  [style-map]
-  {:style {:background "rgba(0,0,0,0.04)"}})
+(defn string->css [css-string]
+  (->> (map #(str/split % #":") (str/split (get css-string "style") #";"))
+       (reduce (fn [acc [property value]]
+                 (assoc acc (keyword property) value)) {})))
 
 (defn str->hiccup
   [string]
   (cond (= string "span")   :span
         (= string "style")  :style
+        (= string ", ")     " "
         :else               string))
 
 (defn crawl
@@ -55,7 +57,7 @@
                                              (.-object (get jsonml 1))
                                              (.-config (get jsonml 1))))]
                          (mapv jsonml->hiccup jsonml))
-    (object? jsonml)   (jsonml-style jsonml)
+    (object? jsonml)   {:style (string->css (js->clj jsonml))}
     :else              (str->hiccup jsonml)))
 
 (defn tab [data]

--- a/src/day8/re_frame/trace/app_state.cljs
+++ b/src/day8/re_frame/trace/app_state.cljs
@@ -6,7 +6,8 @@
             [cljs.pprint :refer [pprint]]))
 
 (defn string->css [css-string]
-  (->> (map #(str/split % #":") (str/split (get css-string "style") #";"))
+  (->> (str/split (get css-string "style") #";")
+       (map #(str/split % #":"))
        (reduce (fn [acc [property value]]
                  (assoc acc (keyword property) value)) {})))
 

--- a/src/day8/re_frame/trace/app_state.cljs
+++ b/src/day8/re_frame/trace/app_state.cljs
@@ -23,8 +23,10 @@
   [jsonml]
   (let [expand? (r/atom true)]
     (fn []
-      [:span.re-frame-trace--object
-        {:on-click #(swap! expand? not)}
+      [:span
+        {:class (str/join " " ["re-frame-trace--object"
+                               (when @expand? "expanded")])
+         :on-click #(swap! expand? not)}
         (jsonml->hiccup (if @expand?
                           (cljs-devtools/body-api-call
                             (.-object (get jsonml 1))

--- a/src/day8/re_frame/trace/app_state.cljs
+++ b/src/day8/re_frame/trace/app_state.cljs
@@ -32,20 +32,15 @@
 
 (defn jsonml-style
   [style-map]
-  ; {:style (get style-map "style")}
-  {:style {:background "rgba(0,0,0,0.1)"}})
+  {:style {:background "rgba(0,0,0,0.04)"}})
 
 (defn str->hiccup
   [string]
-  ; (println string)
-  (cond (= string "span")  :span
-        (= string "style") :style
-        ; (= string "}")     nil
-        ; (= string "{")     nil
-        ; (= string " ")     nil
-        ; (= string ", ")    nil
-        :else              string))
-
+  (println string)
+  (cond (= string "span")   :span
+        (= string "style")  :style
+        (= string "object") :span.re-frame-trace--object
+        :else               string))
 
 (defn crawl
   [data]
@@ -63,5 +58,5 @@
 (defn tab [data]
   [:div {:style {:flex "1 0 auto" :width "100%" :height "100%" :display "flex" :flex-direction "column"}}
     [:div.panel-content-scrollable
-      (jsonml->hiccup (js->clj (cljs-devtools/header-api-call data)))]])
+      (jsonml->hiccup (js->clj (cljs-devtools/header-api-call data) :keywordize-keys true))]])
       ; (crawl data)]])

--- a/src/day8/re_frame/trace/app_state.cljs
+++ b/src/day8/re_frame/trace/app_state.cljs
@@ -53,7 +53,7 @@
   (cond
     (array? jsonml)    (if (= "object" (get jsonml 0))
                          [:span.re-frame-trace--object
-                           (jsonml->hiccup (cljs-devtools/header-api-call
+                           (jsonml->hiccup (cljs-devtools/body-api-call
                                              (.-object (get jsonml 1))
                                              (.-config (get jsonml 1))))]
                          (mapv jsonml->hiccup jsonml))

--- a/src/day8/re_frame/trace/app_state.cljs
+++ b/src/day8/re_frame/trace/app_state.cljs
@@ -2,28 +2,9 @@
   (:require [reagent.core :as r]
             [clojure.string :as str]
             [devtools.formatters.core :as cljs-devtools]
-            [day8.re-frame.trace.localstorage :as localstorage]))
+            [day8.re-frame.trace.localstorage :as localstorage]
+            [day8.re-frame.trace.components :as components]))
 
-(defn search-input [{:keys [title placeholder on-save on-change on-stop]}]
-  (let [val  (r/atom title)
-        save #(let [v (-> @val str str/trim)]
-                (when (pos? (count v))
-                  (on-save v)))]
-    (fn []
-      [:input {:type        "text"
-               :value       @val
-               :auto-focus  true
-               :placeholder placeholder
-               :size        (if (> 20 (count (str @val)))
-                              25
-                              (count (str @val)))
-               :on-change   #(do (reset! val (-> % .-target .-value))
-                                 (on-change %))
-               :on-key-down #(case (.-which %)
-                               13 (do
-                                    (save)
-                                    (reset! val ""))
-                               nil)}])))
 
 (defn string->css [css-string]
   "This function converts jsonml css-strings to valid css maps for hiccup.
@@ -100,18 +81,18 @@
       [:div {:style {:flex "1 0 auto" :width "100%" :height "100%" :display "flex" :flex-direction "column"}}
         [:div.panel-content-scrollable {:style {:margin 10}}
           [:div.filter-control-input
-            [search-input {:placeholder ":path :into :app-state"
-                           :on-save (fn [path]
-                                      (if false ;; TODO check if path exists
-                                        (reset! input-error true)
-                                        (do
-                                          ; (reset! input-error false)
-                                          ;; TODO check if input already wrapped in braces
-                                          (swap! subtree-paths conj (cljs.reader/read-string (str "[" path "]"))))))
-                           :on-change #(reset! subtree-input (.. % -target -value))}]]
-            ; (if @input-error
-            ;   [:div.input-error {:style {:color "red" :margin-top 5}}
-            ;    "Please enter a valid path."])]]
+            [components/search-input {:placeholder ":path :into :app-state"
+                                      :on-save (fn [path]
+                                                 (if false ;; TODO check if path exists
+                                                   (reset! input-error true)
+                                                   (do
+                                                     ; (reset! input-error false)
+                                                     ;; TODO check if input already wrapped in braces
+                                                     (swap! subtree-paths #(into #{(cljs.reader/read-string (str "[" path "]"))} %)))))
+                                      :on-change #(reset! subtree-input (.. % -target -value))}]]
+                       ; (if @input-error
+                       ;   [:div.input-error {:style {:color "red" :margin-top 5}}
+                       ;    "Please enter a valid path."])]]
 
           [:div.subtrees {:style {:margin "20px 0"}}
             (doall

--- a/src/day8/re_frame/trace/app_state.cljs
+++ b/src/day8/re_frame/trace/app_state.cljs
@@ -1,7 +1,31 @@
 (ns day8.re-frame.trace.app-state
   (:require [reagent.core :as r]
             [clojure.string :as str]
-            [devtools.formatters.core :as cljs-devtools]))
+            [devtools.formatters.core :as cljs-devtools]
+            [day8.re-frame.trace.localstorage :as localstorage]))
+
+;; TODO move search-input into components ns
+
+(defn search-input [{:keys [title placeholder on-save on-change on-stop]}]
+  (let [val  (r/atom title)
+        save #(let [v (-> @val str str/trim)]
+                (when (pos? (count v))
+                  (on-save v)))]
+    (fn []
+      [:input {:type        "text"
+               :value       @val
+               :auto-focus  true
+               :placeholder placeholder
+               :size        (if (> 20 (count (str @val)))
+                              25
+                              (count (str @val)))
+               :on-change   #(do (reset! val (-> % .-target .-value))
+                                 (on-change %))
+               :on-key-down #(case (.-which %)
+                               13 (do
+                                    (save)
+                                    (reset! val ""))
+                               nil)}])))
 
 (defn string->css [css-string]
   "This function converts jsonml css-strings to valid css maps for hiccup.
@@ -49,7 +73,50 @@
         (= jsonml ", ")             " "
         :else jsonml))))
 
-(defn render-state  [data]
-  [:div {:style {:flex "1 0 auto" :width "100%" :height "100%" :display "flex" :flex-direction "column"}}
-    [:div.panel-content-scrollable
-     (jsonml->hiccup (cljs-devtools/header-api-call @data))]])
+(defn render-state [data]
+  (let [subtree-input  (r/atom "")
+        subtree-paths  (r/atom (localstorage/get "subtree-paths" #{}))
+        input-error    (r/atom false)]
+    (add-watch subtree-paths
+               :update-localstorage
+               (fn [_ _ _ new-state]
+                 (localstorage/save! "subtree-paths" new-state)))
+    (fn []
+      [:div {:style {:flex "1 0 auto" :width "100%" :height "100%" :display "flex" :flex-direction "column"}}
+        [:div.panel-content-scrollable {:style {:margin 10}}
+          [:div.filter-control-input
+            [search-input {:placeholder ":path :into :app-state"
+                           :on-save (fn [path]
+                                      (if false ;; TODO check if path exists in app-state
+                                        (reset! input-error true)
+                                        (do
+                                          ; (reset! input-error false)
+                                          ;; TODO check if input already wrapped in braces
+                                          (swap! subtree-paths conj (cljs.reader/read-string (str "[" path "]"))))))
+                           :on-change #(reset! subtree-input (.. % -target -value))}]]
+            ; (if @input-error
+            ;   [:div.input-error {:style {:color "red" :margin-top 5}}
+            ;    "Please enter a valid path."])]]
+
+          [:div.subtrees {:style {:margin "20px 0"}}
+            (doall
+              (map (fn [path]
+                     ^{:key path}
+                     [:div.subtree-wrapper {:style {:margin "10px 0"}}
+                       [:div.subtree
+                         [:button.subtree-button {:on-click #(swap! subtree-paths disj path)}
+                           [:span.subtree-button-string
+                             (str path)]]
+                         [:div {:style {:margin-top 10
+                                        :margin-left 10
+                                        :padding-bottom 10}}
+                           (if-let [jsonml (cljs-devtools/header-api-call (get-in @data path))]
+                             (jsonml->hiccup jsonml)
+                             (get-in @data path))]]])
+                @subtree-paths))]
+
+          [:div [:h1 {:style {:font-size 20
+                              :margin-top 30
+                              :display "block"}}
+                  "app-state"]]
+          [:div {:style {:margin-top 10}} (jsonml->hiccup (cljs-devtools/header-api-call @data))]]])))

--- a/src/day8/re_frame/trace/app_state.cljs
+++ b/src/day8/re_frame/trace/app_state.cljs
@@ -5,31 +5,6 @@
 
             [cljs.pprint :refer [pprint]]))
 
-(defn css-munge
-  [string]
-  (str/replace string #"\.|/" "-"))
-
-(defn namespace-css
-  [classname]
-  (str "re-frame-trace--" classname))
-
-(defn type-string
-  [obj]
-  (cond
-    (number? obj)    "number"
-    (boolean? obj)   "boolean"
-    (string? obj)    "string"
-    (nil? obj)       "nil"
-    (keyword? obj)   "keyword"
-    (symbol? obj)    "symbol"
-    :else (pr-str (type obj))))
-
-(defn view
-  [data]
-  (if (coll? data)
-    [:div  {:class (str (namespace-css "collection") " " (namespace-css (css-munge (type-string data))))}]
-    [:span {:class (str (namespace-css "primative") " " (namespace-css (css-munge (type-string data))))} (str data)]))
-
 (defn string->css [css-string]
   (->> (map #(str/split % #":") (str/split (get css-string "style") #";"))
        (reduce (fn [acc [property value]]
@@ -41,12 +16,6 @@
         (= string "style")  :style
         (= string ", ")     " "
         :else               string))
-
-(defn crawl
-  [data]
-  (if (coll? data)
-    (into (view data) (mapv crawl data))
-    (view data)))
 
 (declare jsonml->hiccup)
 
@@ -68,10 +37,11 @@
   [jsonml]
   (cond
     (and (array? jsonml)
-         (= "object" (get jsonml 0))) [data-structure jsonml]
+         (= "object" (first jsonml))) [data-structure jsonml]
     (array? jsonml)                   (mapv jsonml->hiccup jsonml)
     (object? jsonml)                  {:style (string->css (js->clj jsonml))}
-    :else                             (str->hiccup jsonml)))
+    (or (string? jsonml)
+        (integer? jsonml))            (str->hiccup jsonml)))
 
 (defn tab [data]
   [:div {:style {:flex "1 0 auto" :width "100%" :height "100%" :display "flex" :flex-direction "column"}}

--- a/src/day8/re_frame/trace/app_state.cljs
+++ b/src/day8/re_frame/trace/app_state.cljs
@@ -1,9 +1,7 @@
 (ns day8.re-frame.trace.app-state
   (:require [reagent.core :as r]
             [clojure.string :as str]
-            [devtools.formatters.core :as cljs-devtools]
-
-            [cljs.pprint :refer [pprint]]))
+            [devtools.formatters.core :as cljs-devtools]))
 
 (defn string->css [css-string]
   (->> (str/split (get css-string "style") #";")
@@ -45,7 +43,7 @@
         :else jsonml))))
 
 
-(defn tab [data]
+(defn render-state  [data]
   [:div {:style {:flex "1 0 auto" :width "100%" :height "100%" :display "flex" :flex-direction "column"}}
     [:div.panel-content-scrollable
-     (jsonml->hiccup (cljs-devtools/header-api-call data))]])
+     (jsonml->hiccup (cljs-devtools/header-api-call @data))]])

--- a/src/day8/re_frame/trace/app_state.cljs
+++ b/src/day8/re_frame/trace/app_state.cljs
@@ -22,7 +22,7 @@
 (defn data-structure
   [jsonml]
   (let [expand? (r/atom true)]
-    (fn []
+    (fn [jsonml]
       [:span
         {:class (str/join " " ["re-frame-trace--object"
                                (when @expand? "expanded")])

--- a/src/day8/re_frame/trace/app_state.cljs
+++ b/src/day8/re_frame/trace/app_state.cljs
@@ -22,13 +22,15 @@
 
 (defn data-structure
   [jsonml]
-  (let [expand? (r/atom true)]
+  (let [expanded? (r/atom true)]
     (fn [jsonml]
       [:span
         {:class (str/join " " ["re-frame-trace--object"
-                               (when @expand? "expanded")])
-         :on-click #(swap! expand? not)}
-        (jsonml->hiccup (if @expand?
+                               (when @expanded? "expanded")])}
+        [:span {:class "toggle"
+                :on-click #(swap! expanded? not)}
+           (if @expanded? "▼" "▶")]
+        (jsonml->hiccup (if @expanded?
                           (cljs-devtools/body-api-call
                             (.-object (get jsonml 1))
                             (.-config (get jsonml 1)))

--- a/src/day8/re_frame/trace/components.cljs
+++ b/src/day8/re_frame/trace/components.cljs
@@ -1,20 +1,28 @@
 (ns day8.re-frame.trace.components
   (:require [reagent.core :as r]
+            [clojure.string :as str]
             [goog.fx.dom :as fx]))
 
-(defn icon-add []
-  [:svg.icon.icon-add
-    {:viewBox "0 0 32 32"}
-    [:title "add"]
-    [:path
-      {:d "M31 12h-11v-11c0-0.552-0.448-1-1-1h-6c-0.552 0-1 0.448-1 1v11h-11c-0.552 0-1 0.448-1 1v6c0 0.552 0.448 1 1 1h11v11c0 0.552 0.448 1 1 1h6c0.552 0 1-0.448 1-1v-11h11c0.552 0 1-0.448 1-1v-6c0-0.552-0.448-1-1-1z"}]])
-
-(defn icon-remove []
-  [:svg.icon.icon-remove
-    {:viewBox "0 0 32 32"}
-    [:title "remove"]
-    [:path
-      {:d "M31.708 25.708c-0-0-0-0-0-0l-9.708-9.708 9.708-9.708c0-0 0-0 0-0 0.105-0.105 0.18-0.227 0.229-0.357 0.133-0.356 0.057-0.771-0.229-1.057l-4.586-4.586c-0.286-0.286-0.702-0.361-1.057-0.229-0.13 0.048-0.252 0.124-0.357 0.228 0 0-0 0-0 0l-9.708 9.708-9.708-9.708c-0-0-0-0-0-0-0.105-0.104-0.227-0.18-0.357-0.228-0.356-0.133-0.771-0.057-1.057 0.229l-4.586 4.586c-0.286 0.286-0.361 0.702-0.229 1.057 0.049 0.13 0.124 0.252 0.229 0.357 0 0 0 0 0 0l9.708 9.708-9.708 9.708c-0 0-0 0-0 0-0.104 0.105-0.18 0.227-0.229 0.357-0.133 0.355-0.057 0.771 0.229 1.057l4.586 4.586c0.286 0.286 0.702 0.361 1.057 0.229 0.13-0.049 0.252-0.124 0.357-0.229 0-0 0-0 0-0l9.708-9.708 9.708 9.708c0 0 0 0 0 0 0.105 0.105 0.227 0.18 0.357 0.229 0.356 0.133 0.771 0.057 1.057-0.229l4.586-4.586c0.286-0.286 0.362-0.702 0.229-1.057-0.049-0.13-0.124-0.252-0.229-0.357z"}]])
+(defn search-input [{:keys [title placeholder on-save on-change on-stop]}]
+  (let [val  (r/atom title)
+        save #(let [v (-> @val str str/trim)]
+                (when (pos? (count v))
+                  (on-save v)))]
+    (fn []
+      [:input {:type        "text"
+               :value       @val
+               :auto-focus  true
+               :placeholder placeholder
+               :size        (if (> 20 (count (str @val)))
+                              25
+                              (count (str @val)))
+               :on-change   #(do (reset! val (-> % .-target .-value))
+                                 (on-change %))
+               :on-key-down #(case (.-which %)
+                               13 (do
+                                    (save)
+                                    (reset! val ""))
+                               nil)}])))
 
 (defn scroll! [el start end time]
   (.play (fx/Scroll. el (clj->js start) (clj->js end) time)))


### PR DESCRIPTION
~~Currently: proof of concept for showing app~~ Collapse/expand inspection of app state using custom formatters provided by [cljs-devtools](https://github.com/binaryage/cljs-devtools) library. ~~It's not interactive yet (:~~

(In other news, I figured a really wind-about workflow for making screen gif demos!)

![re-frame-trace](https://user-images.githubusercontent.com/1589186/30616500-b1d048b2-9d92-11e7-8ec9-15ccd098f112.gif)

Closes #52 