### PR TITLE
Detect re-frame-trace views via 'devtools outer'

### DIFF
--- a/src/day8/re_frame/trace.cljs
+++ b/src/day8/re_frame/trace.cljs
@@ -120,7 +120,7 @@
   (let [rendering? (= (:op-type trace) :render)]
     (if-not rendering?
       true
-      (not (str/includes? (get-in trace [:tags :component-path] "") "day8.re_frame.trace")))
+      (not (str/includes? (get-in trace [:tags :component-path] "") "devtools outer")))
 
 
     #_(if-let [comp-p (get-in trace [:tags :component-path])]


### PR DESCRIPTION
This is more reliable than looking for the namespace, as reagent does not attempt to keep namespace information when compiled with Closure, whereas "devtools outer" is hard-coded as the :display-name for the panel's container and survives compilation/optimization.