### PR TITLE
Update d3

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
                  [org.clojure/clojurescript  "1.9.227"]
                  [reagent                    "0.6.0" :scope "provided"]
                  [re-frame                   "0.9.0" :scope "provided"]
-                 [cljsjs/d3                  "4.2.2-0"]
+                 [cljsjs/d3                  "4.3.0-5"]
                  [binaryage/devtools         "0.9.4"]]
   :plugins [[lein-less "1.7.5"]]
   :deploy-repositories {"releases" :clojars


### PR DESCRIPTION
Old version of d3 has a bad externs file that can cause Closure compiler to throw.

```
-> Closure - Optimizing ...
Closure compilation failed with 1 errors
--- EXTERNS:/Users/.../.m2/repository/cljsjs/d3/4.2.2-0/d3-4.2.2-0.jar!/cljsjs/d3/common/d3.ext.js:670
Object literal contains illegal duplicate key "scaleSequential", disallowed in strict mode
```